### PR TITLE
fix: update Helm chart to use dynamic DB_HOST and v-prefixed image tags

### DIFF
--- a/helm/crossview/templates/configmap.yaml
+++ b/helm/crossview/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   NODE_ENV: {{ .Values.env.NODE_ENV | quote }}
   PORT: {{ .Values.env.PORT | quote }}
-  DB_HOST: {{ .Values.env.DB_HOST | quote }}
+  DB_HOST: {{ if .Values.env.DB_HOST }}{{ .Values.env.DB_HOST | quote }}{{ else }}{{ include "crossview.fullname" . }}-postgres{{ end }}
   DB_PORT: {{ .Values.env.DB_PORT | quote }}
   DB_NAME: {{ .Values.env.DB_NAME | quote }}
   DB_USER: {{ .Values.env.DB_USER | quote }}

--- a/helm/crossview/templates/deployment.yaml
+++ b/helm/crossview/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ if .Values.image.tag }}{{ .Values.image.tag }}{{ else }}v{{ .Chart.AppVersion }}{{ end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/helm/crossview/values.yaml
+++ b/helm/crossview/values.yaml
@@ -9,8 +9,9 @@ global:
 image:
   repository: corpobit/crossview
   pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  # Overrides the image tag whose default is the chart appVersion with "v" prefix.
+  # Default will be "v{appVersion}" (e.g., "v1.5.0")
+  tag: ""
 
 # Application configuration
 app:
@@ -103,7 +104,9 @@ database:
 env:
   NODE_ENV: "production"
   PORT: "3001"
-  DB_HOST: "crossview-postgres"
+  # DB_HOST will be automatically set to the postgres service name based on release name
+  # If you need to override, set it explicitly (e.g., for external database)
+  DB_HOST: ""  # Empty means use template: {{ include "crossview.fullname" . }}-postgres
   DB_PORT: "5432"
   DB_NAME: "crossview"
   DB_USER: "postgres"


### PR DESCRIPTION
- Fix image tag to default to 'v{appVersion}' format (e.g., v1.5.0)
- Fix DB_HOST to dynamically use release-based postgres service name
- DB_HOST now uses template: {{ include "crossview.fullname" . }}-postgres
- Resolves 'getaddrinfo ENOTFOUND crossview-postgres' error
- Allows override of DB_HOST for external databases