### PR TITLE
Fix Helm to use latest Docker image by default

### DIFF
--- a/helm/crossview/templates/deployment.yaml
+++ b/helm/crossview/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ if .Values.image.tag }}{{ .Values.image.tag }}{{ else }}v{{ .Chart.AppVersion }}{{ end }}"
+          image: "{{ .Values.image.repository }}:{{ if .Values.image.tag }}{{ .Values.image.tag }}{{ else }}latest{{ end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.image.platform }}
           # Note: Platform selection via runtimeClassName or nodeSelector may be needed

--- a/helm/crossview/values.yaml
+++ b/helm/crossview/values.yaml
@@ -10,8 +10,8 @@ global:
 image:
   repository: corpobit/crossview
   pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion with "v" prefix.
-  # Default will be "v{appVersion}" (e.g., "v1.5.0")
+  # Overrides the image tag. Default is "latest" to always use the latest released image.
+  # To pin to a specific version, set this to the version tag (e.g., "v2.1.0")
   tag: ""
   # Platform override for multi-arch support (e.g., "linux/amd64" for ARM64 hosts)
   platform: ""


### PR DESCRIPTION
- Change default image tag from v{appVersion} to 'latest'
- This ensures Helm deployments always use the latest released image
- Users can still pin to a specific version by setting image.tag
- Fixes issue where Helm wasn't using newly released images