### PR TITLE
Fix init container: Use DB_PASS instead of DB_PASSWORD

### DIFF
--- a/helm/crossview/templates/deployment.yaml
+++ b/helm/crossview/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           command: ['sh', '-c']
           args:
             - |
-              until PGPASSWORD=$${DB_PASSWORD} psql -h {{ include "crossview.fullname" . }}-postgres -p $${DB_PORT} -U $${DB_USER} -d $${DB_NAME} -c "SELECT 1" > /dev/null 2>&1; do
+              until PGPASSWORD=$${DB_PASS} psql -h {{ include "crossview.fullname" . }}-postgres -p $${DB_PORT} -U $${DB_USER} -d $${DB_NAME} -c "SELECT 1" > /dev/null 2>&1; do
                 echo "Waiting for database to be ready..."
                 sleep 2
               done


### PR DESCRIPTION
- Init container script was using DB_PASSWORD but env var is DB_PASS
- This was causing init container to fail connecting to database
- Fixes database readiness check in init container