### PR TITLE
Fix duplicate app labels in Helm chart postgres templates

### DIFF
--- a/helm/crossview/templates/_helpers.tpl
+++ b/helm/crossview/templates/_helpers.tpl
@@ -48,7 +48,6 @@ Selector labels
 {{- define "crossview.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "crossview.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-app: {{ include "crossview.name" . }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
- Remove legacy 'app' label from crossview.selectorLabels
- Use only standard Kubernetes labels (app.kubernetes.io/*)
- Prevents YAML unmarshal errors when app: crossview-postgres is set via podLabels
- Fixes issue in versions 1.9.0, 2.0.0 where duplicate app labels caused Flux HelmRelease failures
- Follows Kubernetes recommended labeling practices