### PR TITLE
fix: remove context sidebar completely in in-cluster mode and fix ser…

### DIFF
--- a/helm/crossview/templates/service.yaml
+++ b/helm/crossview/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
   selector:

--- a/src/presentation/components/layout/Layout.jsx
+++ b/src/presentation/components/layout/Layout.jsx
@@ -46,11 +46,11 @@ export const Layout = ({ children }) => {
   }, [isInClusterMode]);
 
   const bgColor = getBackgroundColor(colorMode, 'html');
-  const totalLeftWidth = sidebarWidth + contextSidebarWidth;
+  const totalLeftWidth = sidebarWidth + (isInClusterMode ? 0 : contextSidebarWidth);
 
   return (
     <Box minH="100vh" bg={bgColor}>
-      {showContextSidebar && <ContextSidebar />}
+      {!isInClusterMode && showContextSidebar && <ContextSidebar />}
       <Sidebar onToggle={handleSidebarToggle} onResize={handleSidebarResize} />
       <Box 
         ml={`${totalLeftWidth}px`} 

--- a/src/presentation/components/layout/Sidebar.jsx
+++ b/src/presentation/components/layout/Sidebar.jsx
@@ -28,6 +28,10 @@ export const Sidebar = ({ onToggle, onResize }) => {
   const { user, logout, kubernetesRepository, selectedContext, colorMode, selectedContextError, isInClusterMode } = useAppContext();
 
   useEffect(() => {
+    if (isInClusterMode) {
+      setContextSidebarWidth(0);
+      return;
+    }
     const updateContextSidebarWidth = () => {
       const saved = localStorage.getItem('contextSidebarCollapsed');
       setContextSidebarWidth(saved === 'true' ? 0 : 60);
@@ -38,7 +42,7 @@ export const Sidebar = ({ onToggle, onResize }) => {
     };
     window.addEventListener('contextSidebarWidthChanged', handleWidthChange);
     return () => window.removeEventListener('contextSidebarWidthChanged', handleWidthChange);
-  }, []);
+  }, [isInClusterMode]);
 
   useEffect(() => {
     const currentWidth = isCollapsed ? 60 : width;
@@ -224,7 +228,7 @@ export const Sidebar = ({ onToggle, onResize }) => {
       }}
       transition={isResizing ? 'none' : 'width 0.2s, left 0.2s'}
       position="fixed"
-      left={`${contextSidebarWidth}px`}
+      left={`${isInClusterMode ? 0 : contextSidebarWidth}px`}
       top={0}
       zIndex={1000}
       display="flex"
@@ -274,7 +278,7 @@ export const Sidebar = ({ onToggle, onResize }) => {
               </Text>
               </HStack>
             )}
-            {!isCollapsed && (
+            {!isCollapsed && !isInClusterMode && (
               <Box
                 as="button"
                 onClick={() => {


### PR DESCRIPTION


- Remove context sidebar toggle button from Sidebar when in in-cluster mode
- Hide context sidebar completely (not just conditionally render) in in-cluster mode
- Fix service targetPort to use values.yaml instead of hardcoded port name
- Update sidebar positioning to account for in-cluster mode (no context sidebar offset)
- Ensure context sidebar width is 0 in in-cluster mode
closes #89 
closes #88 