### PR TITLE
fix: use template value for postgres health check instead of env var …

### DIFF
--- a/helm/crossview/templates/postgres.yaml
+++ b/helm/crossview/templates/postgres.yaml
@@ -84,7 +84,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - pg_isready -U $(POSTGRES_USER)
+                - pg_isready -U "{{ .Values.env.DB_USER | default "postgres" }}"
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
@@ -94,7 +94,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - pg_isready -U $(POSTGRES_USER)
+                - pg_isready -U "{{ .Values.env.DB_USER | default "postgres" }}"
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 3


### PR DESCRIPTION

- Replace $(POSTGRES_USER) with template value {{ .Values.env.DB_USER }}
- Fixes 'pg_isready: option requires an argument: U' error
- More reliable than environment variable expansion in Kubernetes exec commands
- Health checks now work correctly and allow crossview pod to start