### PR TITLE
fix: helm ingress service reference

### DIFF
--- a/helm/crossview/templates/ingress.yaml
+++ b/helm/crossview/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
             pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "crossview.fullname" $ }}
+                name: {{ include "crossview.fullname" $ }}-service
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}


### PR DESCRIPTION
Now same format as the name of the service in https://github.com/corpobit/crossview/blob/4b47f6f3d5aaa4b503a9ef5cf3bfe48f1a431ee9/helm/crossview/templates/service.yaml#L2-L4

also matches example in 
https://github.com/corpobit/crossview/blob/4b47f6f3d5aaa4b503a9ef5cf3bfe48f1a431ee9/k8s/ingress.yaml#L23-L25
