### PR TITLE
feat: change service type from LoadBalancer to ClusterIP

### DIFF
--- a/crossview-go-server/main.go
+++ b/crossview-go-server/main.go
@@ -3,6 +3,9 @@ package main
 import (
 	"os"
 	"crossview-go-server/bootstrap"
+	
+	// Import OIDC auth provider for Kubernetes client
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 func init() {

--- a/crossview-go-server/services/kubernetes_context.go
+++ b/crossview-go-server/services/kubernetes_context.go
@@ -120,6 +120,10 @@ func (k *KubernetesService) SetContext(ctxName string) error {
 	k.clientset = clientset
 	k.dynamicClient = nil
 	delete(k.failedContexts, targetContext)
+	
+	// Clear managed resources cache when context changes
+	k.managedResourcesCache = make(map[string]map[string]interface{})
+	k.managedResourcesCacheTime = make(map[string]time.Time)
 
 	if k.isInCluster() {
 		k.logger.Infof("Kubernetes client initialized with context: %s", k.currentContext)

--- a/helm/crossview/values.yaml
+++ b/helm/crossview/values.yaml
@@ -75,7 +75,7 @@ healthCheck:
 
 # Service configuration
 service:
-  type: LoadBalancer
+  type: ClusterIP
   port: 80
   targetPort: 3001
   sessionAffinity: ClientIP


### PR DESCRIPTION
- Update Crossview main service to use ClusterIP instead of LoadBalancer
- PostgreSQL service already uses ClusterIP (no change needed)
- Implement managed resources caching with 5-minute TTL
- Add OIDC auth provider support for Kubernetes client
- Fix certificate path issues for Kubernetes connections

closes #96 