### PR TITLE
Fix Chart.yaml version mismatch in OCI registry push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,6 +343,14 @@ jobs:
         with:
           version: '3.13.0'
 
+      - name: Update Helm Chart.yaml with version
+        run: |
+          CHART_VERSION="${{ steps.version.outputs.version }}"
+          sed -i "s/^version:.*/version: $CHART_VERSION/" helm/crossview/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"$CHART_VERSION\"/" helm/crossview/Chart.yaml
+          echo "Updated Chart.yaml to version $CHART_VERSION:"
+          cat helm/crossview/Chart.yaml
+
       - name: Package Helm chart
         run: |
           mkdir -p ./charts


### PR DESCRIPTION
- Update Chart.yaml version in create-release job before packaging
- Ensures the chart version matches the OCI tag version
- Fixes issue where OCI tag was 2.8.0 but Chart.yaml showed 1.5.0

closes #99 