### PR TITLE
docs: update README files for version 2.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@
 
 ![Crossview Dashboard](public/images/dashboard.png)
 
+## Features
+
+- **Real-Time Resource Watching**: Monitor any Kubernetes resource in real-time with event-driven updates using Kubernetes Informers
+- **Multi-Cluster Support**: Manage and switch between multiple Kubernetes contexts seamlessly
+- **Resource Visualization**: Browse and visualize Crossplane resources (providers, XRDs, compositions, claims, etc.)
+- **Resource Details**: View comprehensive resource information including status conditions, metadata, events, and relationships
+- **Modern UI**: Built with React and Chakra UI with dark mode support
+- **High Performance**: Backend built with Go and Gin framework for optimal performance
+- **WebSocket Support**: Real-time updates via WebSocket connections
+- **SSO Integration**: Support for OIDC and SAML authentication
+
 ## Getting Started
 
 ### Prerequisites
@@ -95,7 +106,7 @@ The app will be available at `http://localhost:3001` (both frontend and API)
 
 ## Backend API
 
-The backend API is built with Go and runs on port 3001. It provides the following endpoints:
+The backend API is built with Go using the Gin framework and runs on port 3001. It provides the following endpoints:
 
 - `GET /api/health` - Health check and connection status
 - `GET /api/contexts` - List available Kubernetes contexts
@@ -105,11 +116,12 @@ The backend API is built with Go and runs on port 3001. It provides the followin
 - `GET /api/resource?apiVersion=&kind=&name=&namespace=&context=` - Get single resource
 - `GET /api/events?kind=&name=&namespace=&context=` - Get resource events
 - `GET /api/managed?context=` - List managed resources
+- `GET /api/watch` - WebSocket endpoint for real-time resource watching
 - `POST /api/auth/login` - User login
 - `POST /api/auth/logout` - User logout
 - `GET /api/auth/check` - Check authentication status
 
-The backend uses the Go Kubernetes client to access Kubernetes clusters:
+The backend uses the Go Kubernetes client with Informers for efficient, event-driven resource monitoring:
 
 **When running in a Kubernetes pod:**
 - Automatically uses service account token (no config file needed)
@@ -189,8 +201,6 @@ docker run -p 3001:3001 \
 Create a `docker-compose.yml`:
 
 ```yaml
-version: '3.8'
-
 services:
   crossview:
     build: .
@@ -211,7 +221,7 @@ services:
       - postgres
 
   postgres:
-    image: postgres:15-alpine
+    image: postgres:latest
     environment:
       - POSTGRES_DB=crossview
       - POSTGRES_USER=postgres
@@ -219,7 +229,7 @@ services:
     ports:
       - "8920:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
 
 volumes:
   postgres_data:
@@ -270,11 +280,19 @@ The application loads configuration in this order (highest to lowest priority):
 
 ## Tech Stack
 
+### Frontend
 - **React** - UI library
 - **Vite** - Build tool and dev server
 - **Chakra UI** - Component library
 - **React Router** - Routing
-- **@kubernetes/client-node** - Kubernetes client (for backend)
+- **WebSocket** - Real-time updates
+
+### Backend
+- **Go** - Programming language
+- **Gin** - Web framework
+- **Kubernetes client-go** - Kubernetes API client
+- **Kubernetes Informers** - Event-driven resource watching
+- **PostgreSQL** - Database (via GORM)
 
 ## Contributing
 

--- a/helm/crossview/README.md
+++ b/helm/crossview/README.md
@@ -9,6 +9,13 @@ This Helm chart deploys Crossview, a Crossplane resource visualization and manag
 - A Kubernetes cluster with appropriate RBAC permissions
 - (Optional) Ingress controller if you want to use Ingress
 
+## Recent Updates
+
+- Updated PostgreSQL image to latest version (PostgreSQL 18 compatible)
+- Fixed PostgreSQL volume mount path for PostgreSQL 18 compatibility
+- Improved chart version synchronization in CI/CD pipeline
+- Enhanced OCI registry integration
+
 ## Installation
 
 ### Option 1: Install from OCI Registry (Recommended)
@@ -17,8 +24,8 @@ Install directly from Docker Hub OCI registry. No repository setup needed!
 
 ```bash
 # Install from OCI registry
-helm install crossview oci://corpobit/crossview-chart \
-  --version v1.6.0 \
+helm install crossview oci://docker.io/corpobit/crossview-chart \
+  --version 2.9.0 \
   --namespace crossview \
   --create-namespace \
   --set secrets.dbPassword=your-db-password \
@@ -46,7 +53,7 @@ helm install crossview crossview/crossview \
 helm install crossview crossview/crossview \
   --namespace crossview \
   --create-namespace \
-  --set image.tag=v1.5.0 \
+  --set image.tag=2.9.0 \
   --set app.replicas=3 \
   --set secrets.dbPassword=your-db-password \
   --set secrets.sessionSecret=$(openssl rand -base64 32) \
@@ -80,8 +87,11 @@ The following table lists the configurable parameters and their default values:
 | `ingress.enabled` | Enable Ingress | `false` |
 | `ingress.className` | Ingress class name | `nginx` |
 | `database.enabled` | Enable PostgreSQL database | `true` |
+| `database.image.repository` | PostgreSQL image repository | `postgres` |
+| `database.image.tag` | PostgreSQL image tag | `latest` (PostgreSQL 18) |
 | `database.persistence.enabled` | Enable database persistence | `true` |
 | `database.persistence.size` | Database PVC size | `10Gi` |
+| `database.persistence.accessMode` | Database PVC access mode | `ReadWriteOnce` |
 | `secrets.dbPassword` | Database password (required) | `""` |
 | `secrets.sessionSecret` | Session secret (required) | `""` |
 | `resources.requests.memory` | Memory request | `256Mi` |
@@ -94,7 +104,7 @@ The following table lists the configurable parameters and their default values:
 ```bash
 helm upgrade crossview crossview/crossview \
   --namespace crossview \
-  --set image.tag=v1.5.0 \
+  --set image.tag=2.9.0 \
   --set secrets.dbPassword=your-db-password \
   --set secrets.sessionSecret=your-session-secret
 ```
@@ -143,6 +153,8 @@ helm install crossview crossview/crossview \
 - The session secret should be a secure random string (use `openssl rand -base64 32`)
 - RBAC resources (ClusterRole and ClusterRoleBinding) are created automatically
 - The service account is created with the necessary permissions to read Kubernetes resources
+- PostgreSQL 18 compatibility: The chart uses the latest PostgreSQL image with updated volume mount paths for PostgreSQL 18
+- When upgrading from older versions, ensure your database persistence volume is compatible with PostgreSQL 18
 
 ## Support
 


### PR DESCRIPTION
- Update Helm chart README with PostgreSQL 18 compatibility notes
- Add Features section to main README highlighting real-time watching
- Update backend API documentation to mention Gin framework and WebSocket
- Update Tech Stack section with frontend/backend separation
- Update Helm installation instructions with OCI registry option
- Update docker-compose example to use postgres:latest
- Fix PostgreSQL volume mount paths for PostgreSQL 18 compatibility