### PR TITLE
Fix Helm chart: service sessionAffinity for ClusterIP and ConfigMap s…

### DIFF
--- a/helm/crossview/templates/_helpers.tpl
+++ b/helm/crossview/templates/_helpers.tpl
@@ -61,3 +61,14 @@ Get namespace - defaults to "default" if global.namespace is empty
 {{- end }}
 {{- end }}
 
+{{/*
+Get ConfigMap name - uses existing ConfigMap if specified, otherwise generates one
+*/}}
+{{- define "crossview.configMapName" -}}
+{{- if .Values.config.existingConfigMap }}
+{{- .Values.config.existingConfigMap }}
+{{- else }}
+{{- printf "%s-config" (include "crossview.fullname" .) }}
+{{- end }}
+{{- end }}
+

--- a/helm/crossview/templates/configmap.yaml
+++ b/helm/crossview/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.config.existingConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,4 +13,5 @@ data:
   DB_PORT: {{ .Values.env.DB_PORT | quote }}
   DB_NAME: {{ .Values.env.DB_NAME | quote }}
   DB_USER: {{ .Values.env.DB_USER | quote }}
+{{- end }}
 

--- a/helm/crossview/templates/deployment.yaml
+++ b/helm/crossview/templates/deployment.yaml
@@ -53,21 +53,30 @@ spec:
               done
               echo "Database is ready and accepting connections!"
           env:
+{{- if .Values.config.existingConfigMap }}
+            - name: DB_PORT
+              value: {{ .Values.env.DB_PORT | default "5432" | quote }}
+            - name: DB_NAME
+              value: {{ .Values.env.DB_NAME | default "crossview" | quote }}
+            - name: DB_USER
+              value: {{ .Values.env.DB_USER | default "postgres" | quote }}
+{{- else }}
             - name: DB_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "crossview.fullname" . }}-config
+                  name: {{ include "crossview.configMapName" . }}
                   key: DB_PORT
             - name: DB_NAME
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "crossview.fullname" . }}-config
+                  name: {{ include "crossview.configMapName" . }}
                   key: DB_NAME
             - name: DB_USER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "crossview.fullname" . }}-config
+                  name: {{ include "crossview.configMapName" . }}
                   key: DB_USER
+{{- end }}
             {{- if .Values.secrets.existingSecret }}
             - name: DB_PASS
               valueFrom:
@@ -99,36 +108,41 @@ spec:
               containerPort: {{ .Values.app.port }}
               protocol: TCP
           env:
+{{- if .Values.config.existingConfigMap }}
+            - name: CONFIG_PATH
+              value: /app/config/config.yaml
+{{- else }}
             - name: NODE_ENV
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "crossview.fullname" . }}-config
+                  name: {{ include "crossview.configMapName" . }}
                   key: NODE_ENV
             - name: PORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "crossview.fullname" . }}-config
+                  name: {{ include "crossview.configMapName" . }}
                   key: PORT
             - name: DB_HOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "crossview.fullname" . }}-config
+                  name: {{ include "crossview.configMapName" . }}
                   key: DB_HOST
             - name: DB_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "crossview.fullname" . }}-config
+                  name: {{ include "crossview.configMapName" . }}
                   key: DB_PORT
             - name: DB_NAME
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "crossview.fullname" . }}-config
+                  name: {{ include "crossview.configMapName" . }}
                   key: DB_NAME
             - name: DB_USER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "crossview.fullname" . }}-config
+                  name: {{ include "crossview.configMapName" . }}
                   key: DB_USER
+{{- end }}
             {{- if .Values.secrets.existingSecret }}
             - name: DB_PASS
               valueFrom:
@@ -168,9 +182,19 @@ spec:
           volumeMounts:
             - name: logs
               mountPath: /app/logs
+{{- if .Values.config.existingConfigMap }}
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+{{- end }}
       volumes:
         - name: logs
           emptyDir: {}
+{{- if .Values.config.existingConfigMap }}
+        - name: config
+          configMap:
+            name: {{ include "crossview.configMapName" . }}
+{{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/helm/crossview/templates/postgres.yaml
+++ b/helm/crossview/templates/postgres.yaml
@@ -42,16 +42,23 @@ spec:
             - name: postgres
               containerPort: 5432
           env:
+{{- if .Values.config.existingConfigMap }}
+            - name: POSTGRES_DB
+              value: {{ .Values.env.DB_NAME | default "crossview" | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.env.DB_USER | default "postgres" | quote }}
+{{- else }}
             - name: POSTGRES_DB
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "crossview.fullname" . }}-config
+                  name: {{ include "crossview.configMapName" . }}
                   key: DB_NAME
             - name: POSTGRES_USER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "crossview.fullname" . }}-config
+                  name: {{ include "crossview.configMapName" . }}
                   key: DB_USER
+{{- end }}
             {{- if .Values.secrets.existingSecret }}
             - name: POSTGRES_PASSWORD
               valueFrom:

--- a/helm/crossview/templates/service.yaml
+++ b/helm/crossview/templates/service.yaml
@@ -18,9 +18,9 @@ spec:
       name: http
   selector:
     {{- include "crossview.selectorLabels" . | nindent 4 }}
-  {{- if eq .Values.service.type "LoadBalancer" }}
+  {{- if and (ne .Values.service.type "ExternalName") .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
-  {{- if .Values.service.sessionAffinityTimeout }}
+  {{- if and (eq .Values.service.sessionAffinity "ClientIP") .Values.service.sessionAffinityTimeout }}
   sessionAffinityConfig:
     clientIP:
       timeoutSeconds: {{ .Values.service.sessionAffinityTimeout }}

--- a/helm/crossview/values.schema.json
+++ b/helm/crossview/values.schema.json
@@ -151,7 +151,7 @@
         "type": {
           "type": "string",
           "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"],
-          "default": "LoadBalancer"
+          "default": "ClusterIP"
         },
         "port": {
           "type": "integer",

--- a/helm/crossview/values.yaml
+++ b/helm/crossview/values.yaml
@@ -138,7 +138,16 @@ database:
       drop:
         - ALL
 
-# Environment variables
+# Configuration
+config:
+  # Reference to an existing ConfigMap (if set, ConfigMap creation is skipped)
+  # The existing ConfigMap should contain a 'config.yaml' key with the full configuration file
+  # The application will read database, server, and SSO settings from this file
+  # If not set, the chart will create a ConfigMap with environment variables
+  # Priority: existingConfigMap (as file) > env vars from chart ConfigMap > defaults
+  existingConfigMap: ""  # Set to your ConfigMap name, e.g., "my-crossview-config"
+
+# Environment variables (only used if config.existingConfigMap is not set)
 env:
   NODE_ENV: "production"
   PORT: "3001"


### PR DESCRIPTION
…upport

- Fix service sessionAffinity to work with ClusterIP, NodePort, and LoadBalancer (not just LoadBalancer)
- Update values.schema.json default service type to ClusterIP (matching values.yaml)
- Add support for existing ConfigMap with config.yaml file
- Mount ConfigMap as file when existingConfigMap is set
- Set CONFIG_PATH environment variable for config file mode
- Update documentation for ConfigMap usage
Closes #118 