### PR TITLE
Fix service selector to exclude postgres pods

### DIFF
--- a/helm/crossview/templates/deployment.yaml
+++ b/helm/crossview/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
   selector:
     matchLabels:
       {{- include "crossview.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: app
   template:
     metadata:
       annotations:
@@ -25,6 +26,7 @@ spec:
         {{- end }}
       labels:
         {{- include "crossview.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: app
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/crossview/templates/service.yaml
+++ b/helm/crossview/templates/service.yaml
@@ -18,6 +18,7 @@ spec:
       name: http
   selector:
     {{- include "crossview.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: app
   {{- if and (ne .Values.service.type "ExternalName") .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   {{- if and (eq .Values.service.sessionAffinity "ClientIP") .Values.service.sessionAffinityTimeout }}


### PR DESCRIPTION
Add app.kubernetes.io/component: app label to crossview app pods and service selector to prevent postgres pods from being selected by the crossview service, which was causing 50% traffic failures.
closes #134 