### PR TITLE
Fix version alignment and remove latest tags

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -66,9 +66,16 @@ jobs:
       - name: Update Chart.yaml with version
         run: |
           VERSION="${{ github.event.inputs.version }}"
+          if [[ "$VERSION" != v* ]]; then
+            TAG="v$VERSION"
+          else
+            TAG="$VERSION"
+            VERSION="${VERSION#v}"
+          fi
           sed -i "s/^version:.*/version: $VERSION/" helm/crossview/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" helm/crossview/Chart.yaml
-          echo "Updated Chart.yaml to version $VERSION:"
+          sed -i "s/^appVersion:.*/appVersion: \"$TAG\"/" helm/crossview/Chart.yaml
+          sed -i "s|ghcr.io/corpobit/crossview:v[0-9]\+\.[0-9]\+\.[0-9]\+|ghcr.io/corpobit/crossview:$TAG|" helm/crossview/Chart.yaml
+          echo "Updated Chart.yaml to version $VERSION (appVersion: $TAG):"
           cat helm/crossview/Chart.yaml
 
       - name: Package Helm chart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,8 @@ jobs:
       - name: Update Helm Chart.yaml
         run: |
           sed -i "s/^version:.*/version: ${{ steps.version.outputs.version }}/" helm/crossview/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.version }}\"/" helm/crossview/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.tag }}\"/" helm/crossview/Chart.yaml
+          sed -i "s|ghcr.io/corpobit/crossview:[0-9]\+\.[0-9]\+\.[0-9]\+|ghcr.io/corpobit/crossview:${{ steps.version.outputs.tag }}|" helm/crossview/Chart.yaml
           echo "Updated Chart.yaml:"
           cat helm/crossview/Chart.yaml
 
@@ -197,11 +198,21 @@ jobs:
           sed -i "s/v1\.[0-9]\+\.[0-9]\+/v${{ steps.version.outputs.version }}/g" helm/crossview/README.md || true
           echo "Updated helm/crossview/README.md"
 
-      - name: Update version files (no commit)
+      - name: Commit version updates
         run: |
-          echo "Version files updated locally for release ${{ steps.version.outputs.version }}"
-          echo "Note: Version files are not committed back to main due to branch protection"
-          echo "The release will proceed with the calculated version: ${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json helm/crossview/Chart.yaml
+          if git diff --staged --quiet; then
+            echo "No version changes to commit"
+          else
+            git commit -m "Bump version to ${{ steps.version.outputs.version }}"
+            git push origin HEAD:${{ github.ref_name }} || {
+              echo "Failed to push version update. This may be due to branch protection."
+              echo "The release will proceed, but Chart.yaml in the repo may be out of sync."
+              echo "Consider manually updating Chart.yaml or adjusting branch protection rules."
+            }
+          fi
 
   build-docker-images:
     needs: [check-version-bump, build-and-release]
@@ -303,11 +314,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/crossview:${{ steps.version.outputs.tag }}-linux-amd64 \
             ghcr.io/${{ github.repository_owner }}/crossview:${{ steps.version.outputs.tag }}-linux-arm64
           
-          docker buildx imagetools create --tag ghcr.io/${{ github.repository_owner }}/crossview:latest \
-            ghcr.io/${{ github.repository_owner }}/crossview:${{ steps.version.outputs.tag }}-linux-amd64 \
-            ghcr.io/${{ github.repository_owner }}/crossview:${{ steps.version.outputs.tag }}-linux-arm64
-          
-          echo "Multi-arch manifest created for GHCR: ${{ steps.version.outputs.tag }} and latest"
+          echo "Multi-arch manifest created for GHCR: ${{ steps.version.outputs.tag }}"
 
       - name: Create and push multi-arch manifest to Docker Hub
         run: |
@@ -315,11 +322,7 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/crossview:${{ steps.version.outputs.tag }}-linux-amd64 \
             ${{ secrets.DOCKERHUB_USERNAME }}/crossview:${{ steps.version.outputs.tag }}-linux-arm64
           
-          docker buildx imagetools create --tag ${{ secrets.DOCKERHUB_USERNAME }}/crossview:latest \
-            ${{ secrets.DOCKERHUB_USERNAME }}/crossview:${{ steps.version.outputs.tag }}-linux-amd64 \
-            ${{ secrets.DOCKERHUB_USERNAME }}/crossview:${{ steps.version.outputs.tag }}-linux-arm64
-          
-          echo "Multi-arch manifest created for Docker Hub: ${{ steps.version.outputs.tag }} and latest"
+          echo "Multi-arch manifest created for Docker Hub: ${{ steps.version.outputs.tag }}"
 
   create-release:
     needs: [check-version-bump, build-and-release, create-multi-arch-manifest]
@@ -393,9 +396,11 @@ jobs:
       - name: Update Helm Chart.yaml with version
         run: |
           CHART_VERSION="${{ steps.version.outputs.version }}"
+          CHART_TAG="${{ steps.version.outputs.tag }}"
           sed -i "s/^version:.*/version: $CHART_VERSION/" helm/crossview/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"$CHART_VERSION\"/" helm/crossview/Chart.yaml
-          echo "Updated Chart.yaml to version $CHART_VERSION:"
+          sed -i "s/^appVersion:.*/appVersion: \"$CHART_TAG\"/" helm/crossview/Chart.yaml
+          sed -i "s|ghcr.io/corpobit/crossview:v[0-9]\+\.[0-9]\+\.[0-9]\+|ghcr.io/corpobit/crossview:$CHART_TAG|" helm/crossview/Chart.yaml
+          echo "Updated Chart.yaml to version $CHART_VERSION (appVersion: $CHART_TAG):"
           cat helm/crossview/Chart.yaml
 
       - name: Package Helm chart

--- a/helm/crossview/Chart.yaml
+++ b/helm/crossview/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: crossview
 description: A Helm chart for Crossview - Crossplane resource visualization and management platform
 type: application
-version: 1.5.0
-appVersion: "latest"
+version: 3.4.0
+appVersion: "v3.4.0"
 icon: https://corpobit.github.io/crossview/images/helm-logo.svg
 keywords:
   - kubernetes
@@ -18,7 +18,7 @@ maintainers:
 annotations:
   artifacthub.io/images: |
     - name: crossview
-      image: ghcr.io/corpobit/crossview:latest
+      image: ghcr.io/corpobit/crossview:v3.4.0
     - name: postgres
       image: postgres:latest
 dependencies: []

--- a/helm/crossview/templates/deployment.yaml
+++ b/helm/crossview/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ if .Values.image.tag }}{{ .Values.image.tag }}{{ else }}latest{{ end }}"
+          image: "{{ .Values.image.repository }}:{{ if .Values.image.tag }}{{ .Values.image.tag }}{{ else }}{{ .Chart.AppVersion }}{{ end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.image.platform }}
           # Note: Platform selection via runtimeClassName or nodeSelector may be needed

--- a/helm/crossview/values.yaml
+++ b/helm/crossview/values.yaml
@@ -10,8 +10,8 @@ global:
 image:
   repository: ghcr.io/corpobit/crossview
   pullPolicy: Always
-  # Overrides the image tag. Default is "latest" to always use the latest released image.
-  # To pin to a specific version, set this to the version tag (e.g., "v2.1.0")
+  # Overrides the image tag. If empty, uses Chart.AppVersion (e.g., "1.5.0").
+  # To pin to a specific version, set this to the version tag (e.g., "1.5.0" or "v1.5.0")
   # Alternative: Use Docker Hub by setting repository to "corpobit/crossview"
   tag: ""
   # Platform override for multi-arch support (e.g., "linux/amd64" for ARM64 hosts)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crossview",
-  "version": "1.5.0",
+  "version": "3.4.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- Remove 'latest' tag creation from Docker images
- Align Chart.AppVersion with Docker image tags (v-prefixed format)
- Update deployment template to use Chart.AppVersion instead of 'latest'
- Add automatic version commit back to repository
- Update Chart.yaml annotations to use versioned tags
- Synchronize all version files (package.json, Chart.yaml) to 3.4.0
closes #141 