### PR TITLE
increased resources limitation so that it can fit the required ammoun…

### DIFF
--- a/helm/crossview/README.md
+++ b/helm/crossview/README.md
@@ -114,8 +114,8 @@ The following table lists the configurable parameters and their default values:
 | `secrets.existingSecret` | Reference to existing Secret (if set, Secret creation is skipped) | `""` |
 | `resources.requests.memory` | Memory request | `256Mi` |
 | `resources.requests.cpu` | CPU request | `250m` |
-| `resources.limits.memory` | Memory limit | `512Mi` |
-| `resources.limits.cpu` | CPU limit | `500m` |
+| `resources.limits.memory` | Memory limit | `1Gi` |
+| `resources.limits.cpu` | CPU limit | `1000m` |
 
 ## Upgrading
 

--- a/helm/crossview/values.yaml
+++ b/helm/crossview/values.yaml
@@ -47,13 +47,15 @@ deployment:
       maxUnavailable: 0
 
 # Resource limits and requests
+# Defaults are set for typical clusters. If the pod is OOMKilled when opening the dashboard,
+# increase memory (e.g. 1Gi–2Gi); see docs/TROUBLESHOOTING.md#oomkilled-when-opening-the-dashboard.
 resources:
   requests:
     memory: "256Mi"
     cpu: "250m"
   limits:
-    memory: "512Mi"
-    cpu: "500m"
+    memory: "1Gi"
+    cpu: "1000m"
 
 # Health checks
 healthCheck:


### PR DESCRIPTION
1. Default memory limit increased from 512Mi → 1Gi.
2. Default CPU limit increased from 500m → 1000m.
3. Comment added that if the pod is still OOMKilled when opening the dashboard, increase memory further and see the troubleshooting doc.

closes #150 