### PR TITLE
Feat: Enhance SSO Role Mapping with JMESPath

### DIFF
--- a/helm/crossview/templates/configmap.yaml
+++ b/helm/crossview/templates/configmap.yaml
@@ -32,6 +32,7 @@ data:
   OIDC_EMAIL_ATTRIBUTE: {{ .Values.config.sso.oidc.emailAttribute | default "email" | quote }}
   OIDC_FIRSTNAME_ATTRIBUTE: {{ .Values.config.sso.oidc.firstNameAttribute | default "given_name" | quote }}
   OIDC_LASTNAME_ATTRIBUTE: {{ .Values.config.sso.oidc.lastNameAttribute | default "family_name" | quote }}
+  OIDC_ROLE_ATTRIBUTE_PATH: {{ .Values.config.sso.oidc.roleAttributePath | default "" | quote }}
   SAML_ENABLED: {{ .Values.config.sso.saml.enabled | default false | quote }}
   SAML_ENTRY_POINT: {{ .Values.config.sso.saml.entryPoint | default "http://localhost:8080/realms/crossview/protocol/saml" | quote }}
   SAML_ISSUER: {{ .Values.config.sso.saml.issuer | default "crossview" | quote }}

--- a/helm/crossview/values.schema.json
+++ b/helm/crossview/values.schema.json
@@ -27,7 +27,11 @@
         "pullPolicy": {
           "type": "string",
           "description": "Image pull policy",
-          "enum": ["Always", "IfNotPresent", "Never"],
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ],
           "default": "Always"
         },
         "tag": {
@@ -36,7 +40,10 @@
           "default": ""
         }
       },
-      "required": ["repository", "pullPolicy"]
+      "required": [
+        "repository",
+        "pullPolicy"
+      ]
     },
     "app": {
       "type": "object",
@@ -61,7 +68,11 @@
           "default": 3
         }
       },
-      "required": ["name", "port", "replicas"]
+      "required": [
+        "name",
+        "port",
+        "replicas"
+      ]
     },
     "deployment": {
       "type": "object",
@@ -72,19 +83,28 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["RollingUpdate", "Recreate"],
+              "enum": [
+                "RollingUpdate",
+                "Recreate"
+              ],
               "default": "RollingUpdate"
             },
             "rollingUpdate": {
               "type": "object",
               "properties": {
                 "maxSurge": {
-                  "type": ["string", "integer"],
+                  "type": [
+                    "string",
+                    "integer"
+                  ],
                   "description": "Maximum number of pods that can be created over the desired number",
                   "default": 1
                 },
                 "maxUnavailable": {
-                  "type": ["string", "integer"],
+                  "type": [
+                    "string",
+                    "integer"
+                  ],
                   "description": "Maximum number of pods that can be unavailable during update",
                   "default": 0
                 }
@@ -150,7 +170,12 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"],
+          "enum": [
+            "ClusterIP",
+            "NodePort",
+            "LoadBalancer",
+            "ExternalName"
+          ],
           "default": "ClusterIP"
         },
         "port": {
@@ -161,13 +186,19 @@
           "default": 80
         },
         "targetPort": {
-          "type": ["integer", "string"],
+          "type": [
+            "integer",
+            "string"
+          ],
           "description": "Target port",
           "default": 3001
         },
         "sessionAffinity": {
           "type": "string",
-          "enum": ["None", "ClientIP"],
+          "enum": [
+            "None",
+            "ClientIP"
+          ],
           "default": "ClientIP"
         },
         "sessionAffinityTimeout": {
@@ -218,7 +249,11 @@
                     },
                     "pathType": {
                       "type": "string",
-                      "enum": ["Exact", "Prefix", "ImplementationSpecific"]
+                      "enum": [
+                        "Exact",
+                        "Prefix",
+                        "ImplementationSpecific"
+                      ]
                     }
                   }
                 }
@@ -312,7 +347,11 @@
             },
             "accessMode": {
               "type": "string",
-              "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"],
+              "enum": [
+                "ReadWriteOnce",
+                "ReadOnlyMany",
+                "ReadWriteMany"
+              ],
               "default": "ReadWriteOnce"
             },
             "storageClass": {
@@ -364,7 +403,14 @@
               "properties": {
                 "level": {
                   "type": "string",
-                  "enum": ["debug", "info", "warn", "error", "fatal", "panic"],
+                  "enum": [
+                    "debug",
+                    "info",
+                    "warn",
+                    "error",
+                    "fatal",
+                    "panic"
+                  ],
                   "default": "info"
                 }
               }
@@ -455,6 +501,9 @@
                 },
                 "lastNameAttribute": {
                   "type": "string"
+                },
+                "roleAttributePath": {
+                  "type": "string"
                 }
               }
             },
@@ -472,7 +521,10 @@
                   "type": "string"
                 },
                 "cert": {
-                  "type": ["string", "null"]
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "callbackURL": {
                   "type": "string"
@@ -537,18 +589,32 @@
                 "secretKeyRef": {
                   "type": "object",
                   "properties": {
-                    "name": {"type": "string"},
-                    "key": {"type": "string"}
+                    "name": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["name", "key"]
+                  "required": [
+                    "name",
+                    "key"
+                  ]
                 },
                 "configMapKeyRef": {
                   "type": "object",
                   "properties": {
-                    "name": {"type": "string"},
-                    "key": {"type": "string"}
+                    "name": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["name", "key"]
+                  "required": [
+                    "name",
+                    "key"
+                  ]
                 }
               }
             }
@@ -566,18 +632,32 @@
                 "secretKeyRef": {
                   "type": "object",
                   "properties": {
-                    "name": {"type": "string"},
-                    "key": {"type": "string"}
+                    "name": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["name", "key"]
+                  "required": [
+                    "name",
+                    "key"
+                  ]
                 },
                 "configMapKeyRef": {
                   "type": "object",
                   "properties": {
-                    "name": {"type": "string"},
-                    "key": {"type": "string"}
+                    "name": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["name", "key"]
+                  "required": [
+                    "name",
+                    "key"
+                  ]
                 }
               }
             }
@@ -591,8 +671,12 @@
           "type": "object",
           "description": "DEPRECATED: Keys in existing secret",
           "properties": {
-            "dbPassword": {"type": "string"},
-            "sessionSecret": {"type": "string"}
+            "dbPassword": {
+              "type": "string"
+            },
+            "sessionSecret": {
+              "type": "string"
+            }
           }
         }
       }
@@ -683,4 +767,3 @@
     }
   }
 }
-

--- a/helm/crossview/values.yaml
+++ b/helm/crossview/values.yaml
@@ -186,6 +186,7 @@ config:
       emailAttribute: email
       firstNameAttribute: given_name
       lastNameAttribute: family_name
+      roleAttributePath: ""
     saml:
       enabled: false
       entryPoint: http://localhost:8080/realms/crossview/protocol/saml


### PR DESCRIPTION
## Description
This PR introduces robust role mapping capabilities using JMESPath expressions in the SSO configuration. It specifically addresses the need to map user roles based on complex conditions and standard OIDC claims.

## Key Changes

### SSO & Role Mapping
- **Configured `OIDC_ROLE_ATTRIBUTE_PATH` or via `sso.oidc.roleAttributePath` in the `config.yaml`**:
  ```jmespath
  (contains(['...', ...], email) && 'admin' || "custom:team" == 'editor' && 'editor' || 'user'
  ```

### Testing
- **Added Unit Tests**:
  - `TestSSOService_HandleOIDCCallback_RoleMapping` in `sso_service_test.go` covering:
    - Simple and nested attribute mapping.
    - Custom attribute conditions (`custom:team`).
    - Handling of missing attributes.
  - Updated test setup to mock OIDC provider responses and prevent external network calls.

### Security
- **Dependency Updates**: Upgraded `golang.org/x/crypto` to address a known vulnerability.

### Limitations
- **Role Mapping**: Mapping roles based on group membership (e.g., `cognito:groups`) is currently **not implemented/supported** as this information is not returned in the standard OIDC `userinfo` response. Currently, role mapping relies on attributes available in the `userinfo` endpoint. Will add this feature via another PR.


## Verification
- **Automated Tests**:
  - Ran `go test -v ./services/...` - All tests passed, confirming the JMESPath logic handles edge cases correctly.