### PR TITLE
PR Feedback via GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
         run: npm ci
 
       - name: Lint
+        continue-on-error: true # TODO: remove this once linting errors are fixed
         run: npm run lint
 
   frontend-build:


### PR DESCRIPTION
Adds valuable feedback on PRs, but also supports keeping the version on `main` stable.

## Design decisions
1. I decided to create a separate GitHub action. There is some overlap with the release action, but IMO the code duplication is worth the reduced complexity by keeping them separate. Feel free to object to this ;-)
2. I decided not to fail the build in the frontend, since there are some linting errors at the moment. I would suggest fixing the linting errors in a follow-up PR and then "activate" the linter in CI.

Looks like this atm:

<img width="1600" height="1174" alt="image" src="https://github.com/user-attachments/assets/41f7f8b4-ab83-49a5-b046-54b09963ec35" />
