### PR TITLE
fix(kubernetes): defer RUnlock after conditional re-lock in GetContexts

### DIFF
--- a/crossview-go-server/services/kubernetes_service.go
+++ b/crossview-go-server/services/kubernetes_service.go
@@ -89,8 +89,6 @@ func (k *KubernetesService) GetContexts() ([]string, error) {
 	}
 
 	k.mu.RLock()
-	defer k.mu.RUnlock()
-
 	if k.kubeConfig == nil {
 		k.mu.RUnlock()
 		if err := k.loadKubeConfig(); err != nil {
@@ -98,6 +96,7 @@ func (k *KubernetesService) GetContexts() ([]string, error) {
 		}
 		k.mu.RLock()
 	}
+	defer k.mu.RUnlock()
 
 	contexts := make([]string, 0, len(k.kubeConfig.Contexts))
 	for name := range k.kubeConfig.Contexts {


### PR DESCRIPTION
## Summary

- Fixes a fatal panic (`sync: RUnlock of unlocked RWMutex`) in `KubernetesService.GetContexts` that crashed the pod on the first request
- The `defer k.mu.RUnlock()` was registered immediately after `k.mu.RLock()`, but a manual `k.mu.RUnlock()` call inside the `if kubeConfig == nil` block meant that an early return (on `loadKubeConfig` error) triggered the deferred unlock on an already-unlocked mutex
- Fix: move the `defer` to after the conditional block, so it is only registered once the lock is guaranteed to be held

## Test plan

- [ ] Run existing tests: `cd crossview-go-server && go test ./...`
- [ ] Deploy via Docker Compose with a valid `~/.kube/config` mounted and verify `GET /contexts` responds correctly
- [ ] Deploy via Docker Compose with an **invalid/missing** kubeconfig path and verify the server returns an error without crashing

Fixes #172