### PR TITLE
feat: add PostgreSQL SSL/TLS connection support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist-ssr
 # Configuration files (contain sensitive info)
 config/database.json
 config/config.yaml
+certs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,63 +1,15 @@
 # Changelog
 
-# v3.6.0 (March 2026)
+# v3.8.0-rc.2 (March 2026)
 
-This release brings authentication flexibility, UI enhancements, important bug fixes for resource visibility and events, Helm chart improvements, organization migration to `crossplane-contrib`, and better governance/documentation. The database is now optional in certain auth modes for lighter deployments.
 
-**Pre-release testing summary:** Iterated through 7 release candidates (rc.1 → rc.7) with fixes applied rapidly between March 1–5, 2026.
+## Features & Enhancements
 
-## 🚀 Features & Enhancements
+- **Handle missing Kubernetes API resources gracefully**  
+  - Add `IsMissingKubernetesResourceError` helper to classify missing-resource cases, including the “the server could not find the requested resource” message.
+  - Use that helper in Kubernetes resource listing so unsupported APIs return an empty result instead of bubbling up as an error.
+  - Update the Kubernetes controller to treat those missing-resource errors as `200 OK` with empty `items`, avoiding the 500 path.
+  - Add tests for the new helper and for the controller behavior when `Function` APIs are unavailable.
 
-- **Flexible authentication modes**  
-  Added support for `header` (trust an HTTP header for user identity) and `none` (disable auth entirely) modes, in addition to existing methods.  
-  Configurable via Helm values: `server.auth.mode`, `trustedHeader`, `createUsers`, `defaultRole`.  
-  Database is skipped when using `header` or `none` modes → enables lighter, stateless deployments.  
-  UI now adapts dynamically based on `/api/auth/check` response.  
-  Full documentation and local testing examples (including nginx header proxy setup) included.
-
-- **External secrets support**  
-  Added compatibility with external secret management; removed mandatory database dependency in non-authenticated scenarios.  
-  Updated example configurations to reflect these changes.
-
-- **UI visualization improvements**  
-  Enhanced YAML parser and syntax highlighter.  
-  Implemented custom floating edges for React Flow (better graph visualization of resources and relationships).
-
-## 🐛 Bug Fixes
-
-- Fixed event fetching tabs for composite resources and managed resources (#182)
-- Resolved role selection dialog issues in user management (create & edit dialogs) (#179)
-- Corrected Helm chart icon image URL (#178)
-- Fixed "ready resources" filter not working correctly in the global search page (#176)
-
-## 🔧 Maintenance & Housekeeping
-
-- **Organization migration**  
-  Moved repo from `corpobit` → `crossplane-contrib` (#175)
-
-- **Documentation & governance**  
-  Added/updates: Contributing guide, MAINTAINERS file, SECURITY.md policy, README table of contents + community links, CODE_OF_CONDUCT.md (#167 & related)
-
-- **Other fixes & contributions**  
-  Kubernetes client: deferred `RUnlock` after conditional re-lock in `GetContexts` (thanks @wnqueiroz)  
-  Reverted earlier problematic security patches (Feb 10) to stabilize the branch
-
-- **Release engineering**  
-  Automated version bumps to v3.6.0-rc.1 through v3.6.0-rc.7 (via GitHub Actions bot)
-
-## 📦 Helm Chart & Deployment Changes
-
-- Updated icon image address in chart
-- Better SSO/user management configuration options
-- Adjusted templates for improved testing and deployment reliability
-
-## How to Test / Upgrade
-
-1. Use the latest RC tag: `v3.6.0-rc.7` (or build from `pre-release` branch)
-2. Helm install/upgrade example:
-   ```bash
-   helm upgrade --install crossview oci://ghcr.io/crossplane-contrib/charts/crossview \
-     --version 3.6.0-rc.7 \
-     --namespace crossview --create-namespace \
-     --set server.auth.mode=header \
-     --set trustedHeader=X-Auth-Request-User
+- **Updated readme**  
+  - In the readme file `Helm Repository` address was mistakenly pointing to the old organizarion. This is updated now pointing to the valid address.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Crossview can be deployed using Helm, which simplifies Kubernetes deployment and
 ### Add the Helm Repository
 
 ```bash
-helm repo add crossview https://corpobit.github.io/crossview
+helm repo add crossview https://crossplane-contrib.github.io/crossview
 helm repo update
 ```
 

--- a/config/loader.js
+++ b/config/loader.js
@@ -42,6 +42,12 @@ export const loadConfig = (configPath = null) => {
       database: process.env.DB_NAME || fileConfig.database?.database || 'crossview',
       username: process.env.DB_USER || fileConfig.database?.username || 'postgres',
       password: process.env.DB_PASSWORD || fileConfig.database?.password || 'postgres',
+      ssl: {
+      mode: process.env.DB_SSL_MODE || fileConfig.database?.ssl?.mode || 'disable',
+      rootCert: process.env.DB_SSL_ROOT_CERT || fileConfig.database?.ssl?.rootCert || '',
+      cert: process.env.DB_SSL_CERT || fileConfig.database?.ssl?.cert || '',
+      key: process.env.DB_SSL_KEY || fileConfig.database?.ssl?.key || '',
+    },
     },
     server: {
       port: parseInt(process.env.PORT || process.env.SERVER_PORT || fileConfig.server?.port || '3001', 10),

--- a/crossview-go-server/lib/db.go
+++ b/crossview-go-server/lib/db.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"gorm.io/driver/postgres"
@@ -17,14 +18,30 @@ func NewDatabase(env Env, logger Logger) Database {
 		logger.Info("Skipping database connection (auth mode is " + env.AuthMode + ")")
 		return Database{DB: nil}
 	}
-	username := env.DBUsername
-	password := env.DBPassword
-	host := env.DBHost
-	port := env.DBPort
-	dbname := env.DBName
+	sslMode := env.DBSSLMode
+	if sslMode == "" {
+		sslMode = "disable"
+	}
+	dsnParts := []string{
+		fmt.Sprintf("host=%s", env.DBHost),
+		fmt.Sprintf("user=%s", env.DBUsername),
+		fmt.Sprintf("password=%s", env.DBPassword),
+		fmt.Sprintf("dbname=%s", env.DBName),
+		fmt.Sprintf("port=%s", env.DBPort),
+		fmt.Sprintf("sslmode=%s", sslMode),
+		"TimeZone=UTC",
+	}
+	if env.DBSSLRootCert != "" {
+		dsnParts = append(dsnParts, fmt.Sprintf("sslrootcert=%s", env.DBSSLRootCert))
+	}
+	if env.DBSSLCert != "" {
+		dsnParts = append(dsnParts, fmt.Sprintf("sslcert=%s", env.DBSSLCert))
+	}
+	if env.DBSSLKey != "" {
+		dsnParts = append(dsnParts, fmt.Sprintf("sslkey=%s", env.DBSSLKey))
+	}
 
-	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=disable TimeZone=UTC", host, username, password, dbname, port)
-
+	dsn := strings.Join(dsnParts, " ")
 	var db *gorm.DB
 	var err error
 	maxRetries := 5
@@ -42,7 +59,7 @@ func NewDatabase(env Env, logger Logger) Database {
 	}
 
 	if err != nil {
-		logger.Info("DSN: ", dsn)
+		logger.Infof("Database connection failed: host=%s port=%s dbname=%s sslmode=%s", env.DBHost, env.DBPort, env.DBName, sslMode)
 		logger.Panic(err)
 	}
 

--- a/crossview-go-server/lib/env.go
+++ b/crossview-go-server/lib/env.go
@@ -9,26 +9,32 @@ import (
 )
 
 type Env struct {
+	AdminUserName     string `mapstructure:"ADMIN_USERNAME"`
+	AdminPassword     string `mapstructure:"ADMIN_PASSWORD"`
 	ServerPort        string `mapstructure:"SERVER_PORT"`
 	Environment       string `mapstructure:"ENV"`
 	LogOutput         string `mapstructure:"LOG_OUTPUT"`
 	LogLevel          string `mapstructure:"LOG_LEVEL"`
-	DBUsername        string `mapstructure:"DB_USER"`
-	DBPassword        string `mapstructure:"DB_PASS"`
-	DBHost            string `mapstructure:"DB_HOST"`
-	DBPort            string `mapstructure:"DB_PORT"`
-	DBName            string `mapstructure:"DB_NAME"`
 	SessionSecret     string `mapstructure:"SESSION_SECRET"`
 	CORSOrigin        string `mapstructure:"CORS_ORIGIN"`
 	AuthMode          string `mapstructure:"AUTH_MODE"`
 	AuthTrustedHeader string `mapstructure:"AUTH_TRUSTED_HEADER"`
 	AuthCreateUsers   bool   `mapstructure:"AUTH_CREATE_USERS"`
 	AuthDefaultRole   string `mapstructure:"AUTH_DEFAULT_ROLE"`
-	OIDCEnabled       bool   `mapstructure:"OIDC_ENABLED"`
-	SAMLEnabled       bool   `mapstructure:"SAML_ENABLED"`
-	DBEnabled         bool   `mapstructure:"DB_ENABLED"`
-	AdminUserName     string `mapstructure:"ADMIN_USERNAME"`
-	AdminPassword     string `mapstructure:"ADMIN_PASSWORD"`
+
+	DBUsername    string `mapstructure:"DB_USER"`
+	DBPassword    string `mapstructure:"DB_PASS"`
+	DBHost        string `mapstructure:"DB_HOST"`
+	DBPort        string `mapstructure:"DB_PORT"`
+	DBName        string `mapstructure:"DB_NAME"`
+	DBSSLMode     string `mapstructure:"DB_SSL_MODE"`
+	DBSSLRootCert string `mapstructure:"DB_SSL_ROOT_CERT"`
+	DBSSLCert     string `mapstructure:"DB_SSL_CERT"`
+	DBSSLKey      string `mapstructure:"DB_SSL_KEY"`
+	DBEnabled     bool   `mapstructure:"DB_ENABLED"`
+
+	OIDCEnabled bool `mapstructure:"OIDC_ENABLED"`
+	SAMLEnabled bool `mapstructure:"SAML_ENABLED"`
 }
 
 func NewEnv() Env {
@@ -80,6 +86,29 @@ func NewEnv() Env {
 		getConfigValue("database.port", viper.GetString("DB_PORT"), "5432"))
 	env.DBName = getEnvOrDefault("DB_NAME", getEnvOrDefault("DB_DATABASE",
 		getConfigValue("database.database", viper.GetString("DB_NAME"), "crossview")))
+	env.DBSSLMode = firstNonEmpty(
+		os.Getenv("DB_SSL_MODE"),
+		os.Getenv("DB_SSLMODE"),
+		getConfigValue("database.ssl.mode", viper.GetString("DB_SSL_MODE"), "disable"),
+	)
+
+	env.DBSSLRootCert = firstNonEmpty(
+		os.Getenv("DB_SSL_ROOT_CERT"),
+		os.Getenv("DB_SSLROOTCERT"),
+		getConfigValue("database.ssl.rootCert", viper.GetString("DB_SSL_ROOT_CERT"), ""),
+	)
+
+	env.DBSSLCert = firstNonEmpty(
+		os.Getenv("DB_SSL_CERT"),
+		os.Getenv("DB_SSLCERT"),
+		getConfigValue("database.ssl.cert", viper.GetString("DB_SSL_CERT"), ""),
+	)
+
+	env.DBSSLKey = firstNonEmpty(
+		os.Getenv("DB_SSL_KEY"),
+		os.Getenv("DB_SSLKEY"),
+		getConfigValue("database.ssl.key", viper.GetString("DB_SSL_KEY"), ""),
+	)
 
 	env.SessionSecret = getEnvOrDefault("SESSION_SECRET",
 		getConfigValue("server.session.secret", viper.GetString("SESSION_SECRET"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,14 @@ services:
       - "8920:5432"
     volumes:
       - postgres_data:/var/lib/postgresql
+      - ./certs/server.crt:/var/lib/postgresql/server.crt:ro
+      - ./certs/server.key:/var/lib/postgresql/server.key:ro
+      - ./certs/ca.crt:/var/lib/postgresql/ca.crt:ro
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/var/lib/postgresql/server.crt
+      -c ssl_key_file=/var/lib/postgresql/server.key
+      -c ssl_ca_file=/var/lib/postgresql/ca.crt
     restart: unless-stopped
 
   keycloak:

--- a/helm/crossview/templates/configmap.yaml
+++ b/helm/crossview/templates/configmap.yaml
@@ -16,6 +16,10 @@ data:
   DB_ENABLED: {{ .Values.config.database.enabled | default false | quote }}
   DB_NAME: {{ .Values.config.database.database | default "crossview" | quote }}
   DB_USER: {{ .Values.config.database.username | default "postgres" | quote }}
+  DB_SSL_MODE: {{ .Values.config.database.ssl.mode | default "disable" | quote }}
+  DB_SSL_ROOT_CERT: {{ .Values.config.database.ssl.rootCert | default "" | quote }}
+  DB_SSL_CERT: {{ .Values.config.database.ssl.cert | default "" | quote }}
+  DB_SSL_KEY: {{ .Values.config.database.ssl.key | default "" | quote }}
   PORT: {{ .Values.config.server.port | default 3001 | quote }}
 {{- $auth := .Values.config.server.auth | default dict }}
 {{- $authHeader := $auth.header | default dict }}

--- a/helm/crossview/templates/deployment.yaml
+++ b/helm/crossview/templates/deployment.yaml
@@ -115,6 +115,26 @@ spec:
                 configMapKeyRef:
                   name: {{ include "crossview.configMapName" . }}
                   key: DB_USER
+            - name: DB_SSL_MODE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "crossview.configMapName" . }}
+                  key: DB_SSL_MODE
+            - name: DB_SSL_ROOT_CERT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "crossview.configMapName" . }}
+                  key: DB_SSL_ROOT_CERT
+            - name: DB_SSL_CERT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "crossview.configMapName" . }}
+                  key: DB_SSL_CERT
+            - name: DB_SSL_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "crossview.configMapName" . }}
+                  key: DB_SSL_KEY
             - name: PORT
               valueFrom:
                 configMapKeyRef:

--- a/helm/crossview/values.yaml
+++ b/helm/crossview/values.yaml
@@ -137,6 +137,11 @@ config:
     port: 5432
     database: crossview
     username: postgres
+    ssl:
+        mode: disable
+        rootCert: ""
+        cert: ""
+        key: ""
   server:
     port: 3001
     auth:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crossview",
-  "version": "3.6.0-rc.7",
+  "version": "3.8.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crossview",
-      "version": "3.6.0-rc.7",
+      "version": "3.8.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@chakra-ui/react": "^3.30.0",


### PR DESCRIPTION
- Add DB_SSL_MODE, DB_SSL_ROOT_CERT, DB_SSL_CERT, DB_SSL_KEY env vars
- Build DSN dynamically to support sslmode, sslrootcert, sslcert, sslkey
- Remove password from connection failure log output
- Update Helm chart values, configmap, and deployment templates
- Update config.yaml and loader.js to use ssl object instead of boolean
- Default sslmode=disable for backward compatibility

## PostgreSQL SSL/TLS Connection Support

With this change, Crossview supports configurable SSL modes for PostgreSQL connections via the DB_SSL_MODE environment variable (default: disable).

### Possible values for DB_SSL_MODE

| Value | Encryption | Server Verification | DB_SSL_ROOT_CERT required? | DB_SSL_CERT + DB_SSL_KEY required? |
|---|---|---|---|---|
| disable | No | No | No | No |
| allow | Maybe | No | No | No |
| prefer | Maybe | No | No | No |
| require | Yes | No | No | No |
| verify-ca | Yes | CA only | Yes | No |
| verify-full | Yes | CA + hostname | Yes | No |

DB_SSL_ROOT_CERT is required when using verify-ca or verify-full. It must point to the path of the CA certificate file inside the container.

DB_SSL_CERT and DB_SSL_KEY are only required when the PostgreSQL server enforces mutual TLS (client certificate authentication). This is uncommon for most managed database providers.

### Environment variables

| Variable | Description | Default |
|---|---|---|
| DB_SSL_MODE | PostgreSQL SSL connection mode | disable |
| DB_SSL_ROOT_CERT | Path to CA certificate file | (empty) |
| DB_SSL_CERT | Path to client certificate file | (empty) |
| DB_SSL_KEY | Path to client private key file | (empty) |

### Examples

No SSL (default, local development):

DB_SSL_MODE=disable

Encrypt traffic without verifying the server (quick cloud setup):

DB_SSL_MODE=require

Verify the server certificate against a trusted CA (recommended for cloud databases):

DB_SSL_MODE=verify-ca
DB_SSL_ROOT_CERT=/etc/certs/db-ca.pem

Verify CA and also check the server hostname matches the certificate CN/SAN (strictest):

DB_SSL_MODE=verify-full
DB_SSL_ROOT_CERT=/etc/certs/db-ca.pem

Mutual TLS (server and client both verify each other, rare):

DB_SSL_MODE=verify-full
DB_SSL_ROOT_CERT=/etc/certs/db-ca.pem
DB_SSL_CERT=/etc/certs/client.crt
DB_SSL_KEY=/etc/certs/client.key

### Helm values examples

No SSL:

```yaml
config:
  database:
    ssl:
      mode: disable
```

Encrypted without verification:

```yaml
config:
  database:
    ssl:
      mode: require
```
CA verification:
```yaml
config:
  database:
    ssl:
      mode: verify-ca
      rootCert: /etc/certs/db-ca.pem
```
Full verification:
```yaml
config:
  database:
    ssl:
      mode: verify-full
      rootCert: /etc/certs/db-ca.pem
```
Mutual TLS:
```yaml
config:
  database:
    ssl:
      mode: verify-full
      rootCert: /etc/certs/db-ca.pem
      cert: /etc/certs/client.crt
      key: /etc/certs/client.key
```

closes #194 