### PR TITLE
fix(helm): validate release version against existing GitHub releases

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g., 1.0.0)'
+        description: 'Version to publish — must match an existing GitHub release (e.g., 3.8.0 or v3.8.0)'
         required: true
         type: string
 
@@ -12,8 +12,65 @@ permissions:
   contents: write
 
 jobs:
+  validate-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
+      tag: ${{ steps.validate.outputs.tag }}
+    steps:
+      - name: Validate version against existing releases
+        id: validate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          VERSION="$INPUT_VERSION"
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::No version provided."
+            exit 1
+          fi
+
+          CLEAN_VERSION="${VERSION#v}"
+          TAG="v${CLEAN_VERSION}"
+
+          RELEASES=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName --jq '.[].tagName' 2>&1) || {
+            echo "::error::Failed to fetch releases. Ensure the repository has at least one published release."
+            exit 1
+          }
+
+          if [ -z "$RELEASES" ]; then
+            echo "::error::No releases found in this repository. Create an application release first before publishing a Helm chart."
+            exit 1
+          fi
+
+          AVAILABLE=$(echo "$RELEASES" | sort -rV | head -20)
+
+          MATCH_FOUND=false
+          while IFS= read -r release_tag; do
+            if [ "$release_tag" = "$TAG" ] || [ "$release_tag" = "$CLEAN_VERSION" ]; then
+              MATCH_FOUND=true
+              break
+            fi
+          done <<< "$RELEASES"
+
+          if [ "$MATCH_FOUND" = false ]; then
+            echo "::error::Version '${INPUT_VERSION}' does not match any existing release."
+            echo ""
+            echo "Available versions:"
+            echo "$AVAILABLE"
+            echo ""
+            echo "Please use one of the versions listed above."
+            exit 1
+          fi
+
+          echo "version=$CLEAN_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Validated: version=$CLEAN_VERSION tag=$TAG"
+
   test:
     runs-on: ubuntu-latest
+    needs: validate-version
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -45,7 +102,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [validate-version, test]
     
     steps:
       - name: Checkout code
@@ -64,14 +121,10 @@ jobs:
           version: '3.13.0'
 
       - name: Update Chart.yaml with version
+        env:
+          VERSION: ${{ needs.validate-version.outputs.version }}
+          TAG: ${{ needs.validate-version.outputs.tag }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
-          if [[ "$VERSION" != v* ]]; then
-            TAG="v$VERSION"
-          else
-            TAG="$VERSION"
-            VERSION="${VERSION#v}"
-          fi
           sed -i "s/^version:.*/version: $VERSION/" helm/crossview/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"$TAG\"/" helm/crossview/Chart.yaml
           sed -i "s|ghcr.io/crossplane-contrib/crossview:v[0-9]\+\.[0-9]\+\.[0-9]\+|ghcr.io/crossplane-contrib/crossview:$TAG|" helm/crossview/Chart.yaml
@@ -325,6 +378,6 @@ jobs:
           if git diff --staged --quiet && git diff --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "Update Helm chart to version ${{ github.event.inputs.version }}"
+            git commit -m "Update Helm chart to version ${{ needs.validate-version.outputs.version }}"
             git push origin gh-pages || git push origin gh-pages --force-with-lease
           fi


### PR DESCRIPTION
Adding a validate version gate job to the Helm release workflow to validate the input version against the versions already released on GitHub. This will prevent the publication of arbitrary versions of Helm charts.

What changed:

1. helm-release.yml: Introduced a new validate version job to fetch releases using the GitHub API
2. The test and release jobs are dependent on the validation job succeeding
3. Error message with versions displayed when validation fails
4. Jobs are using validated versions rather than user input