### PR TITLE
fix(ci): enforce semantic versioning validation in release workflows

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -34,6 +34,14 @@ jobs:
           CLEAN_VERSION="${VERSION#v}"
           TAG="v${CLEAN_VERSION}"
 
+          if [[ ! "$CLEAN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$ ]]; then
+            echo "::error::Version '$VERSION' does not follow Semantic Versioning format (vMAJOR.MINOR.PATCH)"
+            echo ""
+            echo "Valid examples: 1.0.0, v2.3.1, v10.5.0, 3.8.0-rc.1"
+            echo "Invalid examples: v1.0, version-2, 1.2.3-beta!"
+            exit 1
+          fi
+
           RELEASES=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName --jq '.[].tagName' 2>&1) || {
             echo "::error::Failed to fetch releases. Ensure the repository has at least one published release."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,15 @@ jobs:
 
           echo "New version: $NEW_VERSION"
 
+      - name: Validate semantic versioning format
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$ ]]; then
+            echo "::error::Version '$VERSION' does not follow Semantic Versioning format (MAJOR.MINOR.PATCH[-PRERELEASE])"
+            exit 1
+          fi
+          echo "Version '$VERSION' is valid SemVer"
+
       - name: Update package.json version
         run: |
           npm version ${{ steps.version.outputs.version }} --no-git-tag-version --allow-same-version


### PR DESCRIPTION
Add SemVer format validation to both release workflows to ensure that invalid or non-standard version formats are rejected.

What changed

1. release.yml: validation step after version calculation
2. helm-release.yml: validate-version gate job validates input before any work is done
3. Supports standard SemVer format with optional pre-release suffix (3.8.0-rc.1, etc.)