### PR TITLE
fix(ui): pass namespace when navigating from namespaced XR to MR

### DIFF
--- a/src/presentation/hooks/useResourceData.js
+++ b/src/presentation/hooks/useResourceData.js
@@ -118,13 +118,24 @@ export const useResourceData = (resource) => {
       full.spec.writeConnectionSecretsTo.forEach(r => add('Secret', r, r.namespace || original?.namespace));
     }
 
-    const parentNs = full.spec?.claimRef?.namespace || full.spec?.crossplane?.claimRef?.namespace || full.metadata?.namespace || original?.namespace || null;
+    const xrNamespace = full.metadata?.namespace || original?.namespace || null;
+    const claimNs = full.spec?.claimRef?.namespace || full.spec?.crossplane?.claimRef?.namespace || null;
+    const nativeK8sKinds = ['Deployment','Service','Pod','ConfigMap','Secret','ReplicaSet','StatefulSet','DaemonSet'];
 
     const resourceRefs = full.spec?.resourceRefs || full.spec?.crossplane?.resourceRefs;
     if (resourceRefs?.length) {
       resourceRefs.forEach(ref => {
-        let ns = ref.namespace || (['Deployment','Service','Pod','ConfigMap','Secret','ReplicaSet','StatefulSet','DaemonSet'].includes(ref.kind) ? parentNs : null);
-        add('Managed Resource', ref, ns);
+        let ns = ref.namespace;
+        if (!ns) {
+          if (xrNamespace) {
+            // v2 namespaced XR: managed resources live in the XR's namespace
+            ns = xrNamespace;
+          } else if (claimNs && nativeK8sKinds.includes(ref.kind)) {
+            // v1 cluster-scoped XR: only k8s native kinds inherit the claim namespace
+            ns = claimNs;
+          }
+        }
+        add('Managed Resource', ref, ns || null);
       });
     }
 


### PR DESCRIPTION
When navigating from a namespaced v2 Composite Resource to one of its Managed Resources, the namespace was dropped from the API call, causing a 404 from the Kubernetes API and a 500 in the UI.

The `extractRelations` function merged the XR's own namespace with the Claim's namespace into a single `parentNs`, then only fell back to it for a hardcoded list of native Kubernetes kinds. Crossplane v2 namespaced MRs (e.g. `RecordSet`) are not in that list, so their namespace resolved to `null`.

The fix distinguishes two cases:
- **v2 namespaced XR** (`metadata.namespace` set): all `resourceRefs` inherit the XR's namespace.
- **v1 cluster-scoped XR with a Claim**: only native k8s kinds inherit the Claim's namespace (existing behaviour, unchanged).

Fixes #260
