### PR TITLE
feat: Add Crossview favicon to browser tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/images/crossview-logo.svg" />
+    <link rel="icon" type="image/svg+xml" href="/images/cross-view-logo-sidebar.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/images/crossview-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary

- Replace the default Vite placeholder favicon (`/vite.svg`) with the Crossview logo SVG that already exists in the repository at `public/images/crossview-logo.svg`
- Single-line change in `index.html`

## Motivation

When deploying the service locally (or in production), the browser tab shows the generic Vite logo instead of the Crossview branding. This fix wires up the existing logo asset so the correct icon appears in browser tabs, bookmarks, and pinned tabs.

## Changes

- `index.html`: Update `<link rel="icon">` href from `/vite.svg` to `/images/crossview-logo.svg`

No new assets were added — the SVG was already part of the repository.