### PR TITLE
docs: clarify PostgreSQL is only required for auth_mode=session

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 
 - Node.js 20+ (for frontend development)
 - Go 1.24+ (for backend server)
-- PostgreSQL database (port 8920 by default, or set via `DB_PORT` env var)
+- PostgreSQL database — only required when using `auth_mode: session` (the default). For local development without a database, set `auth_mode: none` in `config/config.yaml` (see `config/examples/config-none.yaml.example`).
 - Kubernetes config file at `~/.kube/config` (or set `KUBECONFIG` env var)
 
 ### Install Dependencies

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -69,6 +69,8 @@ docker run -p 3001:3001 \
   ghcr.io/crossplane-contrib/crossview:latest
 ```
 
+> **Note:** PostgreSQL is only required when using `auth_mode: session` (the default). For local development without a database, copy `config/examples/config-none.yaml.example` to `config/config.yaml` — the backend will skip the database connection entirely.
+
 ## First Steps After Installation
 
 1. **Access the Dashboard**


### PR DESCRIPTION
## Summary

- Updates `README.md` Prerequisites to note that PostgreSQL is only needed for `auth_mode: session` (the default), and points to `config-none.yaml.example` for database-free local dev
- Adds the same note to `docs/GETTING_STARTED.md` below the Docker quick-start section

## Why

Both files listed PostgreSQL as a hard prerequisite. The backend skips the DB connection entirely when `auth_mode` is `none` or `header` ([`lib/db.go:17`](https://github.com/crossplane-contrib/crossview/blob/main/crossview-go-server/lib/db.go#L17)), but this was not documented anywhere in the getting-started path.

## Test plan

- [ ] Docs render correctly on GitHub
- [ ] No code changes — all existing Go tests and ESLint results are unchanged

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)