### PR TITLE
fix(ci): replace free-text helm version input with dropdown

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -4,9 +4,27 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish — must match an existing GitHub release (e.g., 3.8.0 or v3.8.0)'
+        description: 'Select the version to release as a Helm chart (list is kept in sync with GitHub releases)'
         required: true
-        type: string
+        type: choice
+        options:
+          - v4.4.0
+          - v4.4.0-rc.1
+          - v4.3.0
+          - v4.2.0
+          - v4.1.0
+          - v4.0.0
+          - v3.9.0
+          - v3.9.0-rc.4
+          - v3.9.0-rc.3
+          - v3.9.0-rc.2
+          - v3.9.0-rc.1
+          - v3.8.0
+          - v3.8.0-rc.4
+          - v3.8.0-rc.3
+          - v3.8.0-rc.2
+          - v3.8.0-rc.1
+          - v3.6.0
       publish_oci:
         description: 'Push chart package to GHCR (OCI)'
         required: false

--- a/.github/workflows/sync-helm-versions.yml
+++ b/.github/workflows/sync-helm-versions.yml
@@ -1,0 +1,67 @@
+name: Sync Helm Version Choices
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update version choices in helm-release.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 - <<'EOF'
+          import subprocess, re, sys
+
+          result = subprocess.run(
+              ['gh', 'release', 'list', '--limit', '20', '--json', 'tagName', '--jq', '.[].tagName'],
+              capture_output=True, text=True
+          )
+          releases = [r.strip() for r in result.stdout.strip().split('\n') if r.strip()]
+
+          if not releases:
+              print("No releases found, nothing to update.")
+              sys.exit(0)
+
+          with open('.github/workflows/helm-release.yml') as f:
+              content = f.read()
+
+          options_block = (
+              "        options:\n"
+              + "\n".join(f"          - {r}" for r in releases)
+              + "\n"
+          )
+
+          new_content = re.sub(
+              r'        options:\n(?:          - .+\n)+',
+              options_block,
+              content
+          )
+
+          if new_content == content:
+              print("No changes needed.")
+              sys.exit(0)
+
+          with open('.github/workflows/helm-release.yml', 'w') as f:
+              f.write(new_content)
+
+          print(f"Updated with {len(releases)} versions: {releases}")
+          EOF
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/workflows/helm-release.yml
+          git diff --staged --quiet && echo "No changes to commit." || \
+            git commit -m "ci: sync helm version choices from releases" && git push


### PR DESCRIPTION
Closes #208

## What changed

The helm-release workflow had a plain text input for the version field. This meant anyone could type any string, including versions that do not match any real release. The only guard was a validation step that ran after the workflow started.

This PR changes the version input to `type: choice` so the GitHub Actions UI shows a dropdown instead of a text box. Users can only pick from the list, so it is no longer possible to enter a made-up version.

Two files are changed:

**helm-release.yml** - the `version` input type is changed from `string` to `choice`. The options list is seeded with the current 17 release tags from the repository.

**sync-helm-versions.yml** (new) - a workflow that keeps the dropdown list up to date. It runs automatically whenever a new release is published on GitHub. It can also be run manually. It fetches the 20 most recent release tags and rewrites the options block in helm-release.yml, then commits the result.

The existing `validate-version` job is kept as it is. It acts as a safety net for cases where the workflow is triggered via the API directly (e.g. `gh workflow run`), where a choice input does not restrict what value is passed.

## How it works

When a release is published, `sync-helm-versions.yml` runs and updates the options list in `helm-release.yml`. The next time someone opens the helm-release workflow in the GitHub UI, the dropdown will show the updated list.

## Testing

- Trigger `sync-helm-versions` manually and verify it updates the options in helm-release.yml and commits the change.
- Open the helm-release workflow dispatch UI and verify a dropdown appears instead of a text field.
- Verify the existing validation step still fails correctly when triggered via the API with a bad version.