### PR TITLE
feat(relations): show kind badge and health on graph nodes and overview tab

### DIFF
--- a/src/presentation/components/common/ResourceOverview.jsx
+++ b/src/presentation/components/common/ResourceOverview.jsx
@@ -9,6 +9,7 @@ import {
 import { FiExternalLink, FiClock, FiTag, FiLayers, FiSettings, FiInfo } from 'react-icons/fi';
 import { formatRelativeTime } from './resourceUtils.js';
 import { colors, getBorderColor } from '../../utils/theme.js';
+import { getResourceHealth, getHealthColor } from './ResourceRelations/utils.js';
 
 export const ResourceOverview = ({ fullResource, resource, relatedResources, onRelatedClick }) => {
   return (
@@ -999,6 +1000,13 @@ export const ResourceOverview = ({ fullResource, resource, relatedResources, onR
                   <HStack justify="space-between">
                     <VStack align="start" spacing={1}>
                       <HStack spacing={2}>
+                        <Box
+                          w="8px"
+                          h="8px"
+                          borderRadius="full"
+                          bg={getHealthColor(getResourceHealth(related))}
+                          flexShrink={0}
+                        />
                         <Text fontWeight="semibold" fontSize="sm" color="gray.700" _dark={{ color: 'gray.300' }}>{related.type}</Text>
                         <Badge fontSize="xs" colorScheme="blue">{related.kind}</Badge>
                       </HStack>

--- a/src/presentation/components/common/ResourceRelations.jsx
+++ b/src/presentation/components/common/ResourceRelations.jsx
@@ -1,4 +1,4 @@
-import { Box, Text } from '@chakra-ui/react';
+import { Box, Text, Badge } from '@chakra-ui/react';
 import { useMemo, useEffect } from 'react';
 import { getResourceHealth, getHealthColor, getNodeBorderColor } from './ResourceRelations/utils.js';
 import { Legend } from './ResourceRelations/Legend.jsx';
@@ -31,15 +31,13 @@ export const ResourceRelations = ({ resource, relatedResources, colorMode, onNav
       position: { x: 400, y: 300 },
       data: {
         label: (
-          <Box textAlign="center" p={2}>
-            <Text fontWeight="bold" fontSize="sm" color={getTextColor(colorMode, 'primary')}>
+          <Box px={3} py={2} textAlign="center">
+            <Text fontWeight="bold" fontSize="sm" color={getTextColor(colorMode, 'primary')} noOfLines={1} mb={1}>
               {resource.kind || 'Resource'}
             </Text>
-
-            <Text fontSize="xs" color={getTextColor(colorMode, 'secondary')} mt={1}>
+            <Text fontSize="xs" color={getTextColor(colorMode, 'secondary')} noOfLines={1}>
               {resource.name}
             </Text>
-
             {resource.namespace && resource.namespace !== 'default' && (
               <Text fontSize="xs" color={getTextColor(colorMode, 'muted')} mt={1}>
                 ns: {resource.namespace}
@@ -53,7 +51,7 @@ export const ResourceRelations = ({ resource, relatedResources, colorMode, onNav
         border: `2px solid ${getNodeBorderColor(mainHealth, colorMode)}`,
         borderRadius: '8px',
         padding: 0,
-        minWidth: '150px',
+        minWidth: '180px',
         boxSizing: 'border-box',
       },
     };
@@ -73,25 +71,28 @@ export const ResourceRelations = ({ resource, relatedResources, colorMode, onNav
         position: { x, y },
         data: {
           label: (
-            <Box textAlign="center" p={2}>
-              <Text
-                fontWeight="semibold"
-                fontSize="xs"
-                color={getTextColor(colorMode, 'primary')}
-              >
-                {related.type || related.kind}
+            <Box px={3} py={2} textAlign="center">
+              <Text fontWeight="bold" fontSize="sm" color={getTextColor(colorMode, 'primary')} noOfLines={1} mb={1}>
+                {related.kind || related.type}
               </Text>
-
-              <Text
-                fontSize="xs"
-                color={getTextColor(colorMode, 'secondary')}
-                mt={1}
-                maxW="120px"
-                noOfLines={1}
-              >
+              {related.type && (
+                <Badge
+                  fontSize="xs"
+                  colorScheme="blue"
+                  variant="outline"
+                  borderWidth="1px"
+                  opacity={0.7}
+                  textTransform="none"
+                  whiteSpace="normal"
+                  display="inline-block"
+                  mb={1}
+                >
+                  {related.type}
+                </Badge>
+              )}
+              <Text fontSize="xs" color={getTextColor(colorMode, 'secondary')} noOfLines={1}>
                 {related.name}
               </Text>
-
               {related.namespace && related.namespace !== 'default' && (
                 <Text fontSize="xs" color={getTextColor(colorMode, 'muted')} mt={1}>
                   ns: {related.namespace}
@@ -105,7 +106,8 @@ export const ResourceRelations = ({ resource, relatedResources, colorMode, onNav
           border: `2px solid ${getNodeBorderColor(health, colorMode)}`,
           borderRadius: '8px',
           padding: 0,
-          minWidth: '120px',
+          minWidth: '160px',
+          maxWidth: '300px',
           boxSizing: 'border-box',
         },
       };
@@ -164,33 +166,18 @@ export const ResourceRelations = ({ resource, relatedResources, colorMode, onNav
             data: {
               ...node.data,
               label: (
-                <Box textAlign="center" p={2}>
-                  <Text
-                    fontWeight="bold"
-                    fontSize="sm"
-                    color={getTextColor(colorMode, 'primary')}
-                  >
+                <Box px={3} py={2} textAlign="center">
+                  <Text fontWeight="bold" fontSize="sm" color={getTextColor(colorMode, 'primary')} noOfLines={1} mb={1}>
                     {resource?.kind || 'Resource'}
                   </Text>
-
-                  <Text
-                    fontSize="xs"
-                    color={getTextColor(colorMode, 'secondary')}
-                    mt={1}
-                  >
+                  <Text fontSize="xs" color={getTextColor(colorMode, 'secondary')} noOfLines={1}>
                     {resource?.name}
                   </Text>
-
-                  {resource?.namespace &&
-                    resource.namespace !== 'default' && (
-                      <Text
-                        fontSize="xs"
-                        color={getTextColor(colorMode, 'muted')}
-                        mt={1}
-                      >
-                        ns: {resource.namespace}
-                      </Text>
-                    )}
+                  {resource?.namespace && resource.namespace !== 'default' && (
+                    <Text fontSize="xs" color={getTextColor(colorMode, 'muted')} mt={1}>
+                      ns: {resource.namespace}
+                    </Text>
+                  )}
                 </Box>
               ),
             },
@@ -214,32 +201,31 @@ export const ResourceRelations = ({ resource, relatedResources, colorMode, onNav
           data: {
             ...node.data,
             label: (
-              <Box textAlign="center" p={2}>
-                <Text
-                  fontWeight="semibold"
-                  fontSize="xs"
-                  color={getTextColor(colorMode, 'primary')}
-                >
-                  {related.type || related.kind}
+              <Box px={3} py={2} textAlign="center">
+                <Text fontWeight="bold" fontSize="sm" color={getTextColor(colorMode, 'primary')} noOfLines={1} mb={1}>
+                  {related.kind || related.type}
                 </Text>
-
-                <Text
-                  fontSize="xs"
-                  color={getTextColor(colorMode, 'secondary')}
-                  mt={1}
-                  maxW="120px"
-                  noOfLines={1}
-                >
+                {related.type && (
+                  <Badge
+                    fontSize="xs"
+                    colorScheme="blue"
+                    variant="outline"
+                    borderWidth="1px"
+                    opacity={0.7}
+                    textTransform="none"
+                    whiteSpace="normal"
+                    display="inline-block"
+                    mb={1}
+                  >
+                    {related.type}
+                  </Badge>
+                )}
+                <Text fontSize="xs" color={getTextColor(colorMode, 'secondary')} noOfLines={1}>
                   {related.name}
                 </Text>
-
                 {related.namespace &&
                   related.namespace !== 'default' && (
-                    <Text
-                      fontSize="xs"
-                      color={getTextColor(colorMode, 'muted')}
-                      mt={1}
-                    >
+                    <Text fontSize="xs" color={getTextColor(colorMode, 'muted')} mt={1}>
                       ns: {related.namespace}
                     </Text>
                   )}


### PR DESCRIPTION
- Display resource kind as bold title and type as outlined badge on
  relation graph nodes for easier identification
- Add health indicator (border color) to related resource cards in
  the Overview tab's Related Resources section
- Redesign graph nodes: centered layout, fixed min/max width to
  prevent overflow, badge wraps on long type names
- Align visual parity between Overview and Relations tabs
Closes #277 