### PR TITLE
fix(oidc): allow empty issuer to skip discovery for split-horizon

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -26,10 +26,12 @@ jobs:
           version: '3.13.0'
 
       - name: Install Helm unittest plugin
-        # Maintained plugin (the deprecated quintush/helm-unittest fork no longer ships its `untt`
-        # binary, so its install silently failed -> "fork/exec .../untt: no such file or directory").
-        # Pin to a release: an unpinned install checks out main HEAD, whose plugin.yaml uses a
-        # `platformHooks` field that Helm 3.13 can't parse. No `|| true` — fail loudly on install.
+        # Switched off the deprecated quintush/helm-unittest fork (no longer ships its `untt` binary
+        # -> install silently failed -> "fork/exec .../untt: no such file or directory").
+        # v1.0.1 is the latest helm-unittest release that works on this workflow's Helm 3.13.0;
+        # v1.1.1+ (and an unpinned install, which takes the plugin's main HEAD) use a `platformHooks`
+        # plugin.yaml field Helm 3.13 can't parse, so bumping the plugin past v1.0.1 also requires
+        # bumping `azure/setup-helm` above to a newer Helm. No `|| true` — fail loudly on install.
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.0.1
 
       - name: Run Helm Lint

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -26,9 +26,11 @@ jobs:
           version: '3.13.0'
 
       - name: Install Helm unittest plugin
-        run: |
-          helm plugin install https://github.com/quintush/helm-unittest.git || true
-          helm plugin update unittest || true
+        # Maintained plugin (the deprecated quintush/helm-unittest fork no longer ships its `untt`
+        # binary, so its install silently failed -> "fork/exec .../untt: no such file or directory").
+        # Pin to a release: an unpinned install checks out main HEAD, whose plugin.yaml uses a
+        # `platformHooks` field that Helm 3.13 can't parse. No `|| true` — fail loudly on install.
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.0.1
 
       - name: Run Helm Lint
         run: |

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -26,12 +26,7 @@ jobs:
           version: '3.13.0'
 
       - name: Install Helm unittest plugin
-        # Switched off the deprecated quintush/helm-unittest fork (no longer ships its `untt` binary
-        # -> install silently failed -> "fork/exec .../untt: no such file or directory").
-        # v1.0.1 is the latest helm-unittest release that works on this workflow's Helm 3.13.0;
-        # v1.1.1+ (and an unpinned install, which takes the plugin's main HEAD) use a `platformHooks`
-        # plugin.yaml field Helm 3.13 can't parse, so bumping the plugin past v1.0.1 also requires
-        # bumping `azure/setup-helm` above to a newer Helm. No `|| true` — fail loudly on install.
+        # v1.0.1 is the latest helm-unittest release compatible with Helm 3.13 (v1.1.1+ need a newer Helm).
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v1.0.1
 
       - name: Run Helm Lint

--- a/config/loader.js
+++ b/config/loader.js
@@ -76,8 +76,7 @@ export const loadConfig = (configPath = null) => {
       enabled: process.env.SSO_ENABLED === 'true' || fileConfig.sso?.enabled === true,
       oidc: {
         enabled: process.env.OIDC_ENABLED === 'true' || fileConfig.sso?.oidc?.enabled === true,
-        // Default empty (mirrors the Go server): an unset issuer skips OIDC discovery so the
-        // explicit *URL endpoints are used as-is (split-horizon). See #280.
+        // Empty default, mirroring lib/sso_config.go (an unset issuer skips OIDC discovery). See #280.
         issuer: process.env.OIDC_ISSUER || fileConfig.sso?.oidc?.issuer || '',
         clientId: process.env.OIDC_CLIENT_ID || fileConfig.sso?.oidc?.clientId || 'crossview-client',
         clientSecret: process.env.OIDC_CLIENT_SECRET || fileConfig.sso?.oidc?.clientSecret || '',

--- a/config/loader.js
+++ b/config/loader.js
@@ -76,7 +76,6 @@ export const loadConfig = (configPath = null) => {
       enabled: process.env.SSO_ENABLED === 'true' || fileConfig.sso?.enabled === true,
       oidc: {
         enabled: process.env.OIDC_ENABLED === 'true' || fileConfig.sso?.oidc?.enabled === true,
-        // Empty default, mirroring lib/sso_config.go (an unset issuer skips OIDC discovery). See #280.
         issuer: process.env.OIDC_ISSUER || fileConfig.sso?.oidc?.issuer || '',
         clientId: process.env.OIDC_CLIENT_ID || fileConfig.sso?.oidc?.clientId || 'crossview-client',
         clientSecret: process.env.OIDC_CLIENT_SECRET || fileConfig.sso?.oidc?.clientSecret || '',

--- a/config/loader.js
+++ b/config/loader.js
@@ -76,7 +76,9 @@ export const loadConfig = (configPath = null) => {
       enabled: process.env.SSO_ENABLED === 'true' || fileConfig.sso?.enabled === true,
       oidc: {
         enabled: process.env.OIDC_ENABLED === 'true' || fileConfig.sso?.oidc?.enabled === true,
-        issuer: process.env.OIDC_ISSUER || fileConfig.sso?.oidc?.issuer || 'http://localhost:8080/realms/crossview',
+        // Default empty (mirrors the Go server): an unset issuer skips OIDC discovery so the
+        // explicit *URL endpoints are used as-is (split-horizon). See #280.
+        issuer: process.env.OIDC_ISSUER || fileConfig.sso?.oidc?.issuer || '',
         clientId: process.env.OIDC_CLIENT_ID || fileConfig.sso?.oidc?.clientId || 'crossview-client',
         clientSecret: process.env.OIDC_CLIENT_SECRET || fileConfig.sso?.oidc?.clientSecret || '',
         authorizationURL: process.env.OIDC_AUTHORIZATION_URL || fileConfig.sso?.oidc?.authorizationURL || '',

--- a/crossview-go-server/api/controllers/sso/sso_test_helpers.go
+++ b/crossview-go-server/api/controllers/sso/sso_test_helpers.go
@@ -73,8 +73,6 @@ func TestSSOConfig_OIDC_Enabled(t *testing.T) {
 	assert.True(t, cfg.Enabled)
 	assert.True(t, cfg.OIDC.Enabled)
 	assert.False(t, cfg.SAML.Enabled)
-	// Issuer stays empty when unset so OIDC discovery is skipped and the explicit
-	// endpoints are used as-is (split-horizon support). See issue #280.
 	assert.Empty(t, cfg.OIDC.Issuer)
 	assert.Equal(t, "crossview-client", cfg.OIDC.ClientId)
 	assert.Equal(t, "openid profile email", cfg.OIDC.Scope)

--- a/crossview-go-server/api/controllers/sso/sso_test_helpers.go
+++ b/crossview-go-server/api/controllers/sso/sso_test_helpers.go
@@ -73,7 +73,9 @@ func TestSSOConfig_OIDC_Enabled(t *testing.T) {
 	assert.True(t, cfg.Enabled)
 	assert.True(t, cfg.OIDC.Enabled)
 	assert.False(t, cfg.SAML.Enabled)
-	assert.Equal(t, "http://localhost:8080/realms/crossview", cfg.OIDC.Issuer)
+	// Issuer stays empty when unset so OIDC discovery is skipped and the explicit
+	// endpoints are used as-is (split-horizon support). See issue #280.
+	assert.Empty(t, cfg.OIDC.Issuer)
 	assert.Equal(t, "crossview-client", cfg.OIDC.ClientId)
 	assert.Equal(t, "openid profile email", cfg.OIDC.Scope)
 }

--- a/crossview-go-server/lib/sso_config.go
+++ b/crossview-go-server/lib/sso_config.go
@@ -66,8 +66,6 @@ func GetSSOConfig(env Env) SSOConfig {
 func getOIDCConfig(enabledStr string) OIDCConfig {
 	return OIDCConfig{
 		Enabled: enabledStr == "true",
-		// Default empty (not a localhost issuer) so an unset issuer skips OIDC discovery
-		// and the explicit *URL endpoints are used as-is (split-horizon). See #280.
 		Issuer: firstNonEmpty(
 			os.Getenv("OIDC_ISSUER"),
 			viper.GetString("sso.oidc.issuer"),

--- a/crossview-go-server/lib/sso_config.go
+++ b/crossview-go-server/lib/sso_config.go
@@ -66,13 +66,12 @@ func GetSSOConfig(env Env) SSOConfig {
 func getOIDCConfig(enabledStr string) OIDCConfig {
 	return OIDCConfig{
 		Enabled: enabledStr == "true",
-		// No fallback issuer: an empty issuer must stay empty so OIDC discovery is
-		// skipped and the explicit *URL endpoints are used as-is. This enables
-		// split-horizon setups (public authorization URL for the browser + in-cluster
-		// token/userinfo URLs). See https://github.com/crossplane-contrib/crossview/issues/280.
+		// Default empty (not a localhost issuer) so an unset issuer skips OIDC discovery
+		// and the explicit *URL endpoints are used as-is (split-horizon). See #280.
 		Issuer: firstNonEmpty(
 			os.Getenv("OIDC_ISSUER"),
 			viper.GetString("sso.oidc.issuer"),
+			"",
 		),
 		ClientId: firstNonEmpty(
 			os.Getenv("OIDC_CLIENT_ID"),

--- a/crossview-go-server/lib/sso_config.go
+++ b/crossview-go-server/lib/sso_config.go
@@ -66,10 +66,13 @@ func GetSSOConfig(env Env) SSOConfig {
 func getOIDCConfig(enabledStr string) OIDCConfig {
 	return OIDCConfig{
 		Enabled: enabledStr == "true",
+		// No fallback issuer: an empty issuer must stay empty so OIDC discovery is
+		// skipped and the explicit *URL endpoints are used as-is. This enables
+		// split-horizon setups (public authorization URL for the browser + in-cluster
+		// token/userinfo URLs). See https://github.com/crossplane-contrib/crossview/issues/280.
 		Issuer: firstNonEmpty(
 			os.Getenv("OIDC_ISSUER"),
 			viper.GetString("sso.oidc.issuer"),
-			"http://localhost:8080/realms/crossview",
 		),
 		ClientId: firstNonEmpty(
 			os.Getenv("OIDC_CLIENT_ID"),

--- a/docs/SSO_SETUP.md
+++ b/docs/SSO_SETUP.md
@@ -72,7 +72,27 @@ sso:
 3. **Copy the client ID and secret** to your config
 4. **Use the issuer URL** (usually ends with `/realms/...` or `/oauth2/...`)
 
-The implementation supports **OIDC Discovery** - if you provide the `issuer` URL, it will automatically discover the authorization, token, and userinfo endpoints.
+The implementation supports **OIDC Discovery** - if you provide the `issuer` URL, it will automatically discover the authorization, token, and userinfo endpoints. The discovered endpoints take precedence over any explicit `authorizationURL`/`tokenURL`/`userInfoURL` you set.
+
+### Split-horizon endpoints (public authorize + in-cluster token)
+
+Leave `issuer` empty to **skip discovery** and use the explicit `authorizationURL`, `tokenURL`, and `userInfoURL` exactly as written. This is required when the identity provider is reachable at different URLs from the browser and from inside the cluster — a public `authorizationURL` for the user's browser redirect, plus in-cluster `tokenURL`/`userInfoURL` for the server-side code→token exchange and userinfo lookup:
+
+```yaml
+sso:
+  enabled: true
+  oidc:
+    enabled: true
+    issuer: ""                                                   # empty -> discovery skipped
+    authorizationURL: https://idp.example.com/authorize          # browser-reachable
+    tokenURL: http://idp.idp.svc.cluster.local:5556/token        # in-cluster
+    userInfoURL: http://idp.idp.svc.cluster.local:5556/userinfo  # in-cluster
+    clientId: your-client-id
+    clientSecret: your-client-secret
+    callbackURL: https://crossview.example.com/api/auth/oidc/callback
+```
+
+Because a non-empty `issuer` makes discovery override the explicit endpoints, split-horizon setups must leave `issuer` empty.
 
 ## SAML Configuration
 

--- a/helm/crossview/templates/configmap.yaml
+++ b/helm/crossview/templates/configmap.yaml
@@ -30,7 +30,9 @@ data:
   LOG_LEVEL: {{ .Values.config.server.log.level | default "info" | quote }}
   CORS_ORIGIN: {{ .Values.config.server.cors.origin | default "http://localhost:5173" | quote }}
   OIDC_ENABLED: {{ .Values.config.sso.oidc.enabled | default false | quote }}
-  OIDC_ISSUER: {{ .Values.config.sso.oidc.issuer | default "http://localhost:8080/realms/crossview" | quote }}
+  # Empty issuer skips OIDC discovery so the explicit *_URL endpoints below are used verbatim
+  # (enables split-horizon: public authorization URL + in-cluster token/userinfo). See issue #280.
+  OIDC_ISSUER: {{ .Values.config.sso.oidc.issuer | default "" | quote }}
   OIDC_CLIENT_ID: {{ .Values.config.sso.oidc.clientId | default "crossview-client" | quote }}
   OIDC_AUTHORIZATION_URL: {{ .Values.config.sso.oidc.authorizationURL | default "" | quote }}
   OIDC_TOKEN_URL: {{ .Values.config.sso.oidc.tokenURL | default "" | quote }}

--- a/helm/crossview/templates/configmap.yaml
+++ b/helm/crossview/templates/configmap.yaml
@@ -30,8 +30,6 @@ data:
   LOG_LEVEL: {{ .Values.config.server.log.level | default "info" | quote }}
   CORS_ORIGIN: {{ .Values.config.server.cors.origin | default "http://localhost:5173" | quote }}
   OIDC_ENABLED: {{ .Values.config.sso.oidc.enabled | default false | quote }}
-  # Empty issuer skips OIDC discovery so the explicit *_URL endpoints below are used verbatim
-  # (enables split-horizon: public authorization URL + in-cluster token/userinfo). See issue #280.
   OIDC_ISSUER: {{ .Values.config.sso.oidc.issuer | default "" | quote }}
   OIDC_CLIENT_ID: {{ .Values.config.sso.oidc.clientId | default "crossview-client" | quote }}
   OIDC_AUTHORIZATION_URL: {{ .Values.config.sso.oidc.authorizationURL | default "" | quote }}

--- a/helm/crossview/tests/configmap_test.yaml
+++ b/helm/crossview/tests/configmap_test.yaml
@@ -142,3 +142,45 @@ tests:
           path: data.OIDC_CLIENT_ID
           value: "my-client"
 
+  - it: should render an empty OIDC_ISSUER when issuer is not set (skips discovery)
+    set:
+      config:
+        sso:
+          enabled: true
+          oidc:
+            enabled: true
+      secrets:
+        dbPassword: test-password
+        sessionSecret: test-secret
+    asserts:
+      - equal:
+          path: data.OIDC_ISSUER
+          value: ""
+
+  - it: should keep explicit OIDC endpoints for split-horizon when issuer is empty
+    set:
+      config:
+        sso:
+          enabled: true
+          oidc:
+            enabled: true
+            authorizationURL: https://idp.example.com/auth
+            tokenURL: http://idp.idp.svc.cluster.local:5556/token
+            userInfoURL: http://idp.idp.svc.cluster.local:5556/userinfo
+      secrets:
+        dbPassword: test-password
+        sessionSecret: test-secret
+    asserts:
+      - equal:
+          path: data.OIDC_ISSUER
+          value: ""
+      - equal:
+          path: data.OIDC_AUTHORIZATION_URL
+          value: "https://idp.example.com/auth"
+      - equal:
+          path: data.OIDC_TOKEN_URL
+          value: "http://idp.idp.svc.cluster.local:5556/token"
+      - equal:
+          path: data.OIDC_USERINFO_URL
+          value: "http://idp.idp.svc.cluster.local:5556/userinfo"
+

--- a/helm/crossview/values.yaml
+++ b/helm/crossview/values.yaml
@@ -168,8 +168,15 @@ config:
   # sso:
   #   oidc:
   #     enabled: true
+  #     # Identity provider issuer. When set, Crossview runs OIDC discovery
+  #     # (<issuer>/.well-known/openid-configuration) and the discovered endpoints
+  #     # OVERRIDE the explicit *URL values below. Leave issuer empty ("") to skip
+  #     # discovery and use authorizationURL/tokenURL/userInfoURL verbatim — required
+  #     # for split-horizon (public authorizationURL for the browser + in-cluster
+  #     # tokenURL/userInfoURL). See https://github.com/crossplane-contrib/crossview/issues/280.
   #     issuer: http://localhost:8080/realms/crossview
   #     clientId: crossview-client
+  #     # Used verbatim when issuer is empty; otherwise only a fallback if discovery fails.
   #     authorizationURL: ""
   #     tokenURL: ""
   #     userInfoURL: ""

--- a/helm/crossview/values.yaml
+++ b/helm/crossview/values.yaml
@@ -168,15 +168,8 @@ config:
   # sso:
   #   oidc:
   #     enabled: true
-  #     # Identity provider issuer. When set, Crossview runs OIDC discovery
-  #     # (<issuer>/.well-known/openid-configuration) and the discovered endpoints
-  #     # OVERRIDE the explicit *URL values below. Leave issuer empty ("") to skip
-  #     # discovery and use authorizationURL/tokenURL/userInfoURL verbatim — required
-  #     # for split-horizon (public authorizationURL for the browser + in-cluster
-  #     # tokenURL/userInfoURL). See https://github.com/crossplane-contrib/crossview/issues/280.
   #     issuer: http://localhost:8080/realms/crossview
   #     clientId: crossview-client
-  #     # Used verbatim when issuer is empty; otherwise only a fallback if discovery fails.
   #     authorizationURL: ""
   #     tokenURL: ""
   #     userInfoURL: ""


### PR DESCRIPTION
Fixes #280

## Problem

Split-horizon OIDC — a browser-facing `authorizationURL` plus in-cluster `tokenURL`/`userInfoURL` for the server-side code→token exchange and userinfo lookup — can't be configured. The blocker is a hardcoded `http://localhost:8080/realms/crossview` issuer default in **two** places, which forces a non-empty issuer and makes the server run OIDC discovery (whose discovered endpoints then override the explicit ones):

1. **Helm chart** — `templates/configmap.yaml` rendered `OIDC_ISSUER` with `| default "http://localhost:8080/realms/crossview"`, so an unset `issuer` could never render an empty `OIDC_ISSUER`.
2. **Go server** — `lib/sso_config.go` *also* re-defaults an empty `OIDC_ISSUER` back to the same localhost URL via `firstNonEmpty(…, "http://localhost:8080/realms/crossview")`.

> The issue framed "option 1" as a chart-only change, but the chart default alone isn't sufficient: the server applies the **same** localhost fallback, so it would re-populate the issuer and run discovery regardless of what the chart renders. Both defaults have to go for the empty-issuer ("skip discovery") path to be reachable — this PR removes both.

With a non-empty issuer, `services/sso_service.go` runs discovery and the discovered `authorization_endpoint`/`token_endpoint`/`userinfo_endpoint` take precedence over the explicit overrides, so the in-cluster token/userinfo endpoints get bypassed (the wall #121 hit).

## Fix (option 1, end-to-end)

Drop the hardcoded localhost issuer default so an unset/empty `issuer` stays empty. The server already supports this path — when `Issuer == ""` it skips discovery and uses the explicit `authorizationURL`/`tokenURL`/`userInfoURL` verbatim — this just makes that path reachable from config.

| File | Change |
|---|---|
| `helm/crossview/templates/configmap.yaml` | `OIDC_ISSUER` now defaults to `""` |
| `crossview-go-server/lib/sso_config.go` | remove the localhost fallback from issuer resolution |
| `config/loader.js` | mirror the same empty-issuer default in the JS config loader (kept in sync with the Go server) |
| `helm/crossview/values.yaml`, `docs/SSO_SETUP.md` | document discovery-vs-explicit precedence + the split-horizon pattern |
| `helm/crossview/tests/configmap_test.yaml` | new cases: empty issuer → empty `OIDC_ISSUER`; explicit endpoints pass through |
| `…/sso/sso_test_helpers.go` | update the config assertion to expect an empty default |

Configuring split-horizon after this change:

```yaml
config:
  sso:
    oidc:
      enabled: true
      issuer: ""                                                   # empty -> discovery skipped
      authorizationURL: https://idp.example.com/authorize          # browser-reachable
      tokenURL: http://idp.idp.svc.cluster.local:5556/token        # in-cluster
      userInfoURL: http://idp.idp.svc.cluster.local:5556/userinfo  # in-cluster
```

A non-empty `issuer` behaves exactly as before (discovery runs).

## Behavior change & the old default

The default `OIDC_ISSUER` is now empty instead of `http://localhost:8080/realms/crossview`. Enabling OIDC without an `issuer` **and** without explicit endpoints now fails fast with `OIDC authorization URL not configured` instead of silently probing localhost.

The old localhost default existed for the **local Keycloak dev/demo**, and that use case is unchanged: it's already set explicitly in the example configs (`config/examples/config.yaml.example`, `config-session-sso.yaml.example`) that the demo copies into the docker-compose-mounted `config/config.yaml`. Every documented OIDC-enable flow (`docs/CONFIGURATION.md`, `docs/SSO_SETUP.md`, the examples) sets `issuer` explicitly, so none relied on the removed fallback. The localhost default now lives only where it belongs — the example/demo configs — instead of being baked into production config resolution (where it caused this bug).

## CI fix included (pre-existing, unrelated to the OIDC change)

The `Helm Chart Tests` job was failing on this PR before it ran a single chart assertion: `.github/workflows/helm-test.yml` installed the **deprecated `quintush/helm-unittest`** fork, which no longer ships its `untt` binary, so the masked `helm plugin install … || true` left `helm unittest` erroring with `fork/exec …/untt: no such file or directory`. This PR touches `helm/**` and was blocked by it, so it also switches the workflow to the maintained **`helm-unittest/helm-unittest`** plugin pinned to **`v1.0.1`** (an *unpinned* install checks out `main` HEAD, whose `plugin.yaml` uses a `platformHooks` field Helm 3.13 can't parse) and drops `|| true` so a failed install fails loudly. Verified on the runner's **Helm 3.13.0**: 23 tests pass. Happy to split this into its own PR if you'd prefer.

## Validation

- `helm lint` ✓; `helm template` ✓ — default renders `OIDC_ISSUER: ""`, split-horizon renders the explicit URLs, a set `issuer` renders through.
- `helm unittest .` ✓ — 5 suites, 23 tests (verified on both Helm 4.2.2 and the CI's Helm 3.13.0).
- `go build ./...` ✓, `go vet ./...` ✓, `go test ./...` ✓; `node --check config/loader.js` ✓; `actionlint` ✓.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (opened on behalf of @devantler).
